### PR TITLE
Handle script imports when running from build artifacts

### DIFF
--- a/gnoman.py
+++ b/gnoman.py
@@ -43,7 +43,20 @@ from web3.exceptions import ContractLogicError  # L037
 from eth_account import Account  # L038
 from eth_account.signers.local import LocalAccount  # L039
 
-from gnoman.utils.abi import load_safe_abi
+try:  # pragma: no branch - import resolution is environment-dependent.
+    from gnoman.utils.abi import load_safe_abi
+except ImportError:
+    _repo_root = Path(__file__).resolve().parent
+    _project_root = _repo_root.parent
+    _package_dir = _repo_root / "gnoman"
+    for candidate in (_project_root, _repo_root, _package_dir):
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+    try:
+        from gnoman.utils.abi import load_safe_abi
+    except ImportError:
+        from utils.abi import load_safe_abi  # type: ignore[import]
 
 Account.enable_unaudited_hdwallet_features()  # L040
 

--- a/gnoman/core.py
+++ b/gnoman/core.py
@@ -43,11 +43,19 @@ from web3.exceptions import ContractLogicError  # L037
 from eth_account import Account  # L038
 from eth_account.signers.local import LocalAccount  # L039
 
-if __package__ in (None, ""):
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from gnoman.utils.abi import load_safe_abi
-else:
+try:  # pragma: no branch - import resolution is environment-dependent.
     from .utils.abi import load_safe_abi
+except ImportError:
+    _pkg_root = Path(__file__).resolve().parent
+    _project_root = _pkg_root.parent
+    for candidate in (_project_root, _pkg_root):
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+    try:
+        from gnoman.utils.abi import load_safe_abi
+    except ImportError:
+        from utils.abi import load_safe_abi  # type: ignore[import]
 
 Account.enable_unaudited_hdwallet_features()  # L040
 


### PR DESCRIPTION
## Summary
- add resilient import fallback logic to gnoman.core so it can run when executed directly from build artifacts
- mirror the import fallback in the top-level gnoman.py entry point to support standalone execution

## Testing
- python3 -m compileall gnoman gnoman.py

------
https://chatgpt.com/codex/tasks/task_e_68cf60198990832caf9d3ef1423303e5