### PR TITLE
feat: add HD wallet management subsystem

### DIFF
--- a/gnoman/cli.py
+++ b/gnoman/cli.py
@@ -17,6 +17,7 @@ from .commands import (
     secrets,
     sync,
     tx,
+    wallet,
 )
 from .tui import launch_tui
 
@@ -192,6 +193,46 @@ def build_parser() -> argparse.ArgumentParser:
     plugin_swap.add_argument("name", help="Plugin name to hot-swap")
     plugin_swap.add_argument("version", help="Target plugin version")
     plugin_swap.set_defaults(handler=plugin.swap)
+
+    # Wallet commands
+    wallet_parser = subparsers.add_parser("wallet", help="HD wallet management")
+    wallet_sub = wallet_parser.add_subparsers(dest="wallet_command")
+    wallet_sub.required = True
+
+    wallet_new = wallet_sub.add_parser("new", help="Derive a new account from the configured seed")
+    wallet_new.add_argument("--label", required=True, help="Label for the derived account")
+    wallet_new.add_argument(
+        "--path",
+        default="default",
+        help="Derivation path name or explicit template (defaults to 'default')",
+    )
+    wallet_new.set_defaults(handler=wallet.new)
+
+    wallet_list = wallet_sub.add_parser("list", help="List derived accounts")
+    wallet_list.set_defaults(handler=wallet.list_accounts)
+
+    wallet_vanity = wallet_sub.add_parser("vanity", help="Search for a vanity address")
+    wallet_vanity.add_argument("--prefix", help="Hex prefix to match (case-insensitive)")
+    wallet_vanity.add_argument("--suffix", help="Hex suffix to match (case-insensitive)")
+    wallet_vanity.add_argument("--regex", help="Regular expression to match against the address")
+    wallet_vanity.add_argument(
+        "--path",
+        default="vanity",
+        help="Derivation path name or template used during the search",
+    )
+    wallet_vanity.add_argument(
+        "--max-attempts",
+        type=int,
+        default=1_000_000,
+        help="Maximum attempts before aborting the vanity search",
+    )
+    wallet_vanity.add_argument(
+        "--log-every",
+        type=int,
+        default=5_000,
+        help="Emit a progress log every N attempts",
+    )
+    wallet_vanity.set_defaults(handler=wallet.vanity)
 
     return parser
 

--- a/gnoman/commands/wallet.py
+++ b/gnoman/commands/wallet.py
@@ -1,0 +1,86 @@
+"""Command handlers for the wallet subsystem."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Dict, List, Optional
+
+from ..utils import logbook
+from ..wallet import (
+    DerivationResolver,
+    WalletManager,
+    WalletManagerError,
+    WalletSeedError,
+    WalletSeedManager,
+)
+
+_MANAGER: Optional[WalletManager] = None
+
+
+def _service_name() -> str:
+    return os.getenv("GNOMAN_KEYRING_SERVICE", "gnoman")
+
+
+def _manager() -> WalletManager:
+    global _MANAGER
+    if _MANAGER is None:
+        try:
+            seed_manager = WalletSeedManager(service_name=_service_name())
+        except WalletSeedError as exc:
+            raise SystemExit(str(exc)) from exc
+        resolver = DerivationResolver()
+        _MANAGER = WalletManager(seed_manager=seed_manager, resolver=resolver)
+    return _MANAGER
+
+
+def new(args) -> Dict[str, object]:
+    manager = _manager()
+    try:
+        record = manager.create_account(args.label, path=args.path)
+    except WalletManagerError as exc:
+        raise SystemExit(str(exc)) from exc
+    payload = asdict(record)
+    logbook.info({"action": "wallet_new", "label": record.label, "address": record.address, "path": record.derivation_path})
+    print(f"[WALLET] {record.label} -> {record.address} ({record.derivation_path})")
+    return payload
+
+
+def list_accounts(args) -> Dict[str, List[Dict[str, object]]]:
+    manager = _manager()
+    records = [asdict(record) for record in manager.list_accounts()]
+    logbook.info({"action": "wallet_list", "count": len(records)})
+    for rec in records:
+        print(f"[WALLET] {rec['label']} -> {rec['address']} ({rec['derivation_path']})")
+    return {"accounts": records}
+
+
+def vanity(args) -> Dict[str, object]:
+    manager = _manager()
+    try:
+        record = manager.find_vanity(
+            prefix=args.prefix,
+            suffix=args.suffix,
+            regex=args.regex,
+            path=args.path,
+            max_attempts=args.max_attempts,
+            log_every=args.log_every,
+        )
+    except WalletManagerError as exc:
+        raise SystemExit(str(exc)) from exc
+    payload = asdict(record)
+    logbook.info(
+        {
+            "action": "wallet_vanity",
+            "address": record.address,
+            "path": record.derivation_path,
+            "index": record.index,
+            "prefix": args.prefix,
+            "suffix": args.suffix,
+            "regex": args.regex,
+        }
+    )
+    print(
+        f"[WALLET] Vanity match {record.address} ({record.derivation_path}, index={record.index})"
+    )
+    return payload

--- a/gnoman/wallet/__init__.py
+++ b/gnoman/wallet/__init__.py
@@ -1,0 +1,20 @@
+"""Wallet subsystem primitives for GNOMAN."""
+
+from .seed import WalletSeedManager, SeedNotFoundError, WalletSeedError
+from .resolver import DerivationResolver, DerivationError
+from .hd import HDWalletTree
+from .vanity import VanityGenerator, VanitySearchError
+from .manager import WalletManager, WalletManagerError
+
+__all__ = [
+    "WalletSeedManager",
+    "SeedNotFoundError",
+    "WalletSeedError",
+    "DerivationResolver",
+    "DerivationError",
+    "HDWalletTree",
+    "VanityGenerator",
+    "VanitySearchError",
+    "WalletManager",
+    "WalletManagerError",
+]

--- a/gnoman/wallet/hd.py
+++ b/gnoman/wallet/hd.py
@@ -1,0 +1,41 @@
+"""Hierarchical deterministic wallet tree management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from web3 import Web3
+
+from .resolver import DerivationResolver
+from .seed import SeedNotFoundError, WalletSeedManager
+
+Account.enable_unaudited_hdwallet_features()
+
+
+@dataclass
+class HDWalletTree:
+    """Hidden HD wallet tree handling keyed by the shared seed."""
+
+    seed_manager: WalletSeedManager
+    resolver: DerivationResolver
+
+    def get_address(self, index: int, path_override: Optional[str] = None) -> Tuple[str, LocalAccount, str]:
+        """Return ``(address, LocalAccount, derivation_path)`` for ``index``.
+
+        ``path_override`` may be either a named template from the resolver
+        configuration or an explicit derivation string.
+        """
+
+        identifier = path_override or "default"
+        try:
+            path = self.resolver.resolve(identifier, index)
+            mnemonic = self.seed_manager.get_mnemonic()
+            passphrase = self.seed_manager.get_passphrase()
+        except SeedNotFoundError:
+            raise
+        account = Account.from_mnemonic(mnemonic, account_path=path, passphrase=passphrase)
+        address = Web3.to_checksum_address(account.address)
+        return address, account, path

--- a/gnoman/wallet/manager.py
+++ b/gnoman/wallet/manager.py
@@ -1,0 +1,148 @@
+"""High level wallet manager orchestrating derivations and vanity search."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from eth_account.signers.local import LocalAccount
+
+from .hd import HDWalletTree
+from .resolver import DerivationResolver, DerivationError
+from .seed import SeedNotFoundError, WalletSeedError, WalletSeedManager
+from .vanity import VanityGenerator, VanitySearchError
+
+logger = logging.getLogger("gnoman.wallet")
+
+
+class WalletManagerError(RuntimeError):
+    """Raised for wallet management failures."""
+
+
+@dataclass
+class WalletRecord:
+    label: str
+    address: str
+    derivation_path: str
+    path_identifier: str
+    index: int
+
+
+@dataclass
+class WalletManager:
+    seed_manager: WalletSeedManager
+    resolver: DerivationResolver
+    state_path: Path = field(default_factory=lambda: Path.home() / ".gnoman" / "wallet_accounts.json")
+
+    def __post_init__(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self._tree = HDWalletTree(self.seed_manager, self.resolver)
+        self._accounts = self._load_state()
+
+    # -- persistence -------------------------------------------------------
+    def _load_state(self) -> Dict[str, WalletRecord]:
+        if not self.state_path.exists():
+            return {}
+        try:
+            payload = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        records: Dict[str, WalletRecord] = {}
+        for label, data in payload.items():
+            try:
+                records[label] = WalletRecord(**data)
+            except TypeError:
+                continue
+        return records
+
+    def _save_state(self) -> None:
+        serialisable = {label: record.__dict__ for label, record in self._accounts.items()}
+        self.state_path.write_text(json.dumps(serialisable, indent=2), encoding="utf-8")
+
+    # -- helpers -----------------------------------------------------------
+    def _next_index(self, path_identifier: str) -> int:
+        indices = [r.index for r in self._accounts.values() if r.path_identifier == path_identifier]
+        return max(indices, default=-1) + 1
+
+    def _record(self, label: str) -> WalletRecord:
+        if label not in self._accounts:
+            raise WalletManagerError(f"unknown wallet label: {label}")
+        return self._accounts[label]
+
+    # -- public API --------------------------------------------------------
+    def create_account(self, label: str, path: str = "default") -> WalletRecord:
+        if label in self._accounts:
+            raise WalletManagerError(f"label {label!r} already exists")
+        try:
+            index = self._next_index(path)
+            address, _, derivation_path = self._tree.get_address(index, path_override=path)
+        except SeedNotFoundError as exc:
+            raise WalletManagerError("wallet seed not initialised") from exc
+        except DerivationError as exc:
+            raise WalletManagerError(str(exc)) from exc
+        record = WalletRecord(label=label, address=address, derivation_path=derivation_path, path_identifier=path, index=index)
+        self._accounts[label] = record
+        self._save_state()
+        logger.info("[WalletManager] 🧬 Derived address %s at path %s", address, derivation_path)
+        return record
+
+    def get_account(self, label: str) -> WalletRecord:
+        return self._record(label)
+
+    def get_signer(self, label: str) -> LocalAccount:
+        record = self._record(label)
+        try:
+            address, account, _ = self._tree.get_address(record.index, path_override=record.path_identifier)
+        except SeedNotFoundError as exc:
+            raise WalletManagerError("wallet seed not initialised") from exc
+        if address != record.address:
+            logger.warning(
+                "[WalletManager] address drift detected for label %s (expected %s, resolved %s)",
+                label,
+                record.address,
+                address,
+            )
+        return account
+
+    def list_accounts(self) -> List[WalletRecord]:
+        return sorted(self._accounts.values(), key=lambda r: r.label)
+
+    def find_vanity(
+        self,
+        *,
+        prefix: Optional[str] = None,
+        suffix: Optional[str] = None,
+        regex: Optional[str] = None,
+        path: str = "vanity",
+        max_attempts: int = 1_000_000,
+        log_every: int = 5_000,
+    ) -> WalletRecord:
+        generator = VanityGenerator(self._tree, path, log_every)
+        try:
+            result = generator.find_match(prefix=prefix, suffix=suffix, regex=regex, max_attempts=max_attempts)
+        except VanitySearchError as exc:
+            raise WalletManagerError(str(exc)) from exc
+        address = result["address"]
+        derivation_path = result["derivation_path"]
+        index = result["index"]
+        metadata_key = f"WALLET_VANITY::{address}".lower()
+        try:
+            self.seed_manager.store_metadata(
+                metadata_key,
+                json.dumps({"path": derivation_path, "index": index}),
+            )
+        except WalletSeedError as exc:
+            raise WalletManagerError("failed to persist vanity metadata to keyring") from exc
+        logger.info(
+            "[WalletManager] 🧬 Derived address %s at path %s", address, derivation_path
+        )
+        return WalletRecord(
+            label=f"vanity:{address[:8]}",
+            address=address,
+            derivation_path=derivation_path,
+            path_identifier=path,
+            index=index,
+        )

--- a/gnoman/wallet/resolver.py
+++ b/gnoman/wallet/resolver.py
@@ -1,0 +1,84 @@
+"""Resolve configured derivation paths and validate arbitrary overrides."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class DerivationError(RuntimeError):
+    """Raised when derivation path resolution fails."""
+
+
+@dataclass
+class DerivationResolver:
+    """Resolve named derivation templates to fully qualified paths."""
+
+    config_path: Optional[Path] = None
+
+    _PATH_RE = re.compile(r"^m(\/\d+'?)*$")
+
+    def __post_init__(self) -> None:
+        self._templates = self._load_config()
+
+    # -- configuration -----------------------------------------------------
+    def _load_config(self) -> Dict[str, str]:
+        if self.config_path is not None:
+            data = self.config_path.read_text(encoding="utf-8")
+        else:
+            try:
+                data = resources.files("gnoman.wallet_config").joinpath("derivations.json").read_text(encoding="utf-8")
+            except FileNotFoundError as exc:  # pragma: no cover - packaging issue
+                raise DerivationError("wallet derivation config missing") from exc
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise DerivationError("invalid derivations configuration") from exc
+        if not isinstance(payload, dict):
+            raise DerivationError("derivations configuration must be an object")
+        return {str(key): str(value) for key, value in payload.items()}
+
+    # -- accessors ---------------------------------------------------------
+    @property
+    def templates(self) -> Dict[str, str]:
+        return self._templates.copy()
+
+    def available_paths(self) -> Dict[str, str]:
+        return self.templates
+
+    # -- public API --------------------------------------------------------
+    def resolve(self, identifier: str, index: int) -> str:
+        """Resolve ``identifier`` into a derivation path for ``index``.
+
+        ``identifier`` can be a key from the configuration map or an explicit
+        derivation string such as ``m/44'/60'/0'/0/0``. ``index`` is injected
+        by replacing ``{index}`` tokens or, when the template ends with a slash,
+        appended as the final segment.
+        """
+
+        template = self._templates.get(identifier, identifier)
+        if not isinstance(template, str):
+            raise DerivationError(f"invalid derivation template for {identifier}")
+        path = self._materialise(template, index)
+        if not self._PATH_RE.fullmatch(path):
+            raise DerivationError(f"invalid derivation path produced: {path}")
+        return path
+
+    # -- helpers -----------------------------------------------------------
+    def _materialise(self, template: str, index: int) -> str:
+        if "{index}" in template:
+            path = template.replace("{index}", str(index))
+        elif template.endswith("/"):
+            path = f"{template}{index}"
+        elif template.count("/") == 0:
+            # bare index-less template (e.g. "m/44'/60'/0'/0") -> append index
+            path = f"{template}/{index}"
+        else:
+            path = template
+        if "{" in path or "}" in path:
+            raise DerivationError(f"unresolved placeholder in derivation path: {template}")
+        return path

--- a/gnoman/wallet/seed.py
+++ b/gnoman/wallet/seed.py
@@ -1,0 +1,123 @@
+"""Secure master seed handling backed by the keyring service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+try:  # pragma: no cover - depends on runtime environment
+    import keyring  # type: ignore
+except Exception:  # pragma: no cover - if keyring is unavailable
+    keyring = None  # type: ignore
+
+
+class KeyringLike(Protocol):
+    """Protocol describing the subset of keyring used by the wallet."""
+
+    def get_password(self, service: str, key: str) -> Optional[str]:
+        ...
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        ...
+
+    def delete_password(self, service: str, key: str) -> None:
+        ...
+
+
+class WalletSeedError(RuntimeError):
+    """Base exception for seed storage failures."""
+
+
+class SeedNotFoundError(WalletSeedError):
+    """Raised when no seed material could be located."""
+
+
+@dataclass
+class WalletSeedManager:
+    """Encapsulate secure retrieval and storage of wallet seed material.
+
+    The manager never emits the seed in logs and relies on the configured
+    keyring backend for persistence. For tests a custom backend implementing
+    :class:`KeyringLike` can be injected.
+    """
+
+    service_name: str = "gnoman"
+    backend: Optional[KeyringLike] = None
+
+    MNEMONIC_KEY = "WALLET_MASTER_MNEMONIC"
+    ENTROPY_KEY = "WALLET_MASTER_ENTROPY"
+    PASSPHRASE_KEY = "WALLET_PASSPHRASE"
+
+    def __post_init__(self) -> None:
+        if self.backend is None:
+            if keyring is None:
+                raise WalletSeedError("keyring backend is not available")
+            self.backend = keyring  # type: ignore[assignment]
+
+    # -- internal helpers -------------------------------------------------
+    def _get(self, key: str) -> Optional[str]:
+        assert self.backend is not None
+        try:
+            return self.backend.get_password(self.service_name, key)
+        except Exception as exc:  # pragma: no cover - backend specific
+            raise WalletSeedError(f"failed to read {key!r} from keyring") from exc
+
+    def _set(self, key: str, value: str) -> None:
+        assert self.backend is not None
+        try:
+            self.backend.set_password(self.service_name, key, value)
+        except Exception as exc:  # pragma: no cover - backend specific
+            raise WalletSeedError(f"failed to store {key!r} in keyring") from exc
+
+    def _delete(self, key: str) -> None:
+        assert self.backend is not None
+        try:
+            self.backend.delete_password(self.service_name, key)
+        except Exception:  # pragma: no cover - deletion failures are non fatal
+            return
+
+    # -- mnemonic / entropy management ------------------------------------
+    def store_mnemonic(self, mnemonic: str) -> None:
+        if not mnemonic.strip():
+            raise WalletSeedError("mnemonic must not be empty")
+        self._set(self.MNEMONIC_KEY, mnemonic.strip())
+
+    def get_mnemonic(self) -> str:
+        mnemonic = self._get(self.MNEMONIC_KEY)
+        if mnemonic:
+            return mnemonic
+        raise SeedNotFoundError("wallet mnemonic not found in keyring")
+
+    def clear_mnemonic(self) -> None:
+        self._delete(self.MNEMONIC_KEY)
+
+    def store_entropy(self, entropy_hex: str) -> None:
+        if not entropy_hex.strip():
+            raise WalletSeedError("entropy must not be empty")
+        self._set(self.ENTROPY_KEY, entropy_hex.strip())
+
+    def get_entropy(self) -> str:
+        entropy = self._get(self.ENTROPY_KEY)
+        if entropy:
+            return entropy
+        raise SeedNotFoundError("wallet entropy not found in keyring")
+
+    def clear_entropy(self) -> None:
+        self._delete(self.ENTROPY_KEY)
+
+    def store_passphrase(self, passphrase: str) -> None:
+        self._set(self.PASSPHRASE_KEY, passphrase)
+
+    def get_passphrase(self) -> str:
+        value = self._get(self.PASSPHRASE_KEY)
+        return value or ""
+
+    def clear_passphrase(self) -> None:
+        self._delete(self.PASSPHRASE_KEY)
+
+    # -- metadata helpers --------------------------------------------------
+    def store_metadata(self, key: str, value: str) -> None:
+        self._set(key, value)
+
+    def get_metadata(self, key: str) -> Optional[str]:
+        return self._get(key)

--- a/gnoman/wallet/vanity.py
+++ b/gnoman/wallet/vanity.py
@@ -1,0 +1,76 @@
+"""Vanity address generation utilities."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from .hd import HDWalletTree
+
+logger = logging.getLogger("gnoman.wallet")
+
+
+class VanitySearchError(RuntimeError):
+    """Raised when vanity search encounters an error."""
+
+
+@dataclass
+class VanityGenerator:
+    """Iteratively search for addresses matching vanity patterns."""
+
+    tree: HDWalletTree
+    path_identifier: str
+    log_every: int = 5_000
+
+    def find_match(
+        self,
+        *,
+        prefix: Optional[str] = None,
+        suffix: Optional[str] = None,
+        regex: Optional[str] = None,
+        max_attempts: int = 1_000_000,
+    ):
+        """Return the first match for the requested vanity pattern."""
+
+        if not any([prefix, suffix, regex]):
+            raise VanitySearchError("a prefix, suffix, or regex pattern is required")
+        pattern = re.compile(regex, re.IGNORECASE) if regex else None
+        attempts = 0
+        while attempts < max_attempts:
+            address, account, path = self.tree.get_address(attempts, path_override=self.path_identifier)
+            candidate = address.lower()
+            if self._matches(candidate, prefix, suffix, pattern):
+                logger.info("[VanityGenerator] ✅ Found vanity %s at index %s", address, attempts)
+                return {
+                    "address": address,
+                    "account": account,
+                    "index": attempts,
+                    "derivation_path": path,
+                }
+            attempts += 1
+            if attempts % max(1, self.log_every) == 0:
+                logger.info(
+                    "[VanityGenerator] 🔍 %s attempts without match (path=%s)",
+                    attempts,
+                    self.path_identifier,
+                )
+        raise VanitySearchError("vanity search exhausted without success")
+
+    def _matches(
+        self,
+        address: str,
+        prefix: Optional[str],
+        suffix: Optional[str],
+        pattern: Optional[re.Pattern[str]],
+    ) -> bool:
+        prefix_l = prefix.lower() if prefix else None
+        suffix_l = suffix.lower() if suffix else None
+        if prefix_l and not address.startswith(prefix_l):
+            return False
+        if suffix_l and not address.endswith(suffix_l):
+            return False
+        if pattern and not pattern.search(address):
+            return False
+        return True

--- a/gnoman/wallet_config/__init__.py
+++ b/gnoman/wallet_config/__init__.py
@@ -1,0 +1,1 @@
+"""Wallet configuration package providing derivation templates."""

--- a/gnoman/wallet_config/derivations.json
+++ b/gnoman/wallet_config/derivations.json
@@ -1,0 +1,6 @@
+{
+  "default": "m/44'/60'/0'/0/{index}",
+  "trading": "m/44'/60'/0'/1/{index}",
+  "vanity": "m/44'/60'/1337'/{index}",
+  "hidden": "m/44'/60'/1337'/42/{index}"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ gnoman = "gnoman.cli:main"
 include = ["gnoman", "gnoman.*"]
 
 [tool.setuptools.package-data]
-gnoman = ["data/GnosisSafe.json"]
+gnoman = ["data/GnosisSafe.json", "wallet_config/derivations.json"]
 

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,110 @@
+"""Unit tests for the wallet subsystem."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from gnoman.wallet import (
+    DerivationResolver,
+    HDWalletTree,
+    VanityGenerator,
+    WalletManager,
+    WalletManagerError,
+    WalletSeedManager,
+)
+
+MNEMONIC = "test test test test test test test test test test test junk"
+
+
+class InMemoryKeyring:
+    def __init__(self) -> None:
+        self._store: Dict[Tuple[str, str], str] = {}
+
+    def get_password(self, service: str, key: str) -> Optional[str]:
+        return self._store.get((service, key))
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        self._store[(service, key)] = value
+
+    def delete_password(self, service: str, key: str) -> None:
+        self._store.pop((service, key), None)
+
+
+class WalletTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = Path(tempfile.mkdtemp(prefix="gnoman-wallet-test-"))
+        self.config_path = self.temp_dir / "derivations.json"
+        self.config_path.write_text(
+            json.dumps(
+                {
+                    "default": "m/44'/60'/0'/0/{index}",
+                    "trading": "m/44'/60'/0'/1/{index}",
+                    "vanity": "m/44'/60'/1337'/{index}",
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.keyring = InMemoryKeyring()
+        self.seed_manager = WalletSeedManager(service_name="test", backend=self.keyring)
+        self.seed_manager.store_mnemonic(MNEMONIC)
+        self.resolver = DerivationResolver(config_path=self.config_path)
+        self.state_path = self.temp_dir / "wallet_state.json"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_hd_tree_reproducible_derivation(self) -> None:
+        tree = HDWalletTree(self.seed_manager, self.resolver)
+        addr_a, acct_a, path_a = tree.get_address(0, path_override="default")
+        addr_b, acct_b, path_b = tree.get_address(0, path_override="default")
+        self.assertEqual(addr_a, addr_b)
+        self.assertEqual(acct_a.address, acct_b.address)
+        self.assertEqual(path_a, path_b)
+
+    def test_custom_path_resolution(self) -> None:
+        path = self.resolver.resolve("trading", 7)
+        self.assertEqual(path, "m/44'/60'/0'/1/7")
+        explicit = self.resolver.resolve("m/44'/60'/0'/9/{index}", 3)
+        self.assertEqual(explicit, "m/44'/60'/0'/9/3")
+
+    def test_vanity_generator_logs_on_success(self) -> None:
+        tree = HDWalletTree(self.seed_manager, self.resolver)
+        generator = VanityGenerator(tree, "vanity", log_every=1)
+        with self.assertLogs("gnoman.wallet", level=logging.INFO) as captured:
+            result = generator.find_match(prefix="0x", max_attempts=5)
+        self.assertEqual(result["index"], 0)
+        self.assertTrue(any("[VanityGenerator] ✅ Found vanity" in msg for msg in captured.output))
+
+    def test_wallet_manager_persists_vanity_metadata(self) -> None:
+        manager = WalletManager(
+            seed_manager=self.seed_manager,
+            resolver=self.resolver,
+            state_path=self.state_path,
+        )
+        record = manager.find_vanity(prefix="0x", max_attempts=5, log_every=1)
+        metadata_key = f"wallet_vanity::{record.address}".lower()
+        stored = self.seed_manager.get_metadata(metadata_key)
+        self.assertIsNotNone(stored)
+        payload = json.loads(stored)
+        self.assertEqual(payload["index"], record.index)
+        self.assertEqual(payload["path"], record.derivation_path)
+
+    def test_create_account_raises_without_unique_label(self) -> None:
+        manager = WalletManager(
+            seed_manager=self.seed_manager,
+            resolver=self.resolver,
+            state_path=self.state_path,
+        )
+        manager.create_account("alpha", path="default")
+        with self.assertRaises(WalletManagerError):
+            manager.create_account("alpha", path="default")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated wallet subsystem with secure seed handling, derivation resolution, HD tree access, and vanity search utilities
- expose wallet creation, listing, and vanity search workflows through the CLI using the new WalletManager
- ship default derivation templates and unit tests covering deterministic derivations, vanity discovery, and keyring persistence

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68cf864d6ce0832cb459e89a7859fae5