### PR TITLE
Restore mission control CLI with legacy console bridge

### DIFF
--- a/gnoman/cli.py
+++ b/gnoman/cli.py
@@ -1,23 +1,273 @@
-"""Bridge the packaged CLI entrypoint to the original interactive core."""
+"""Argparse CLI bridging mission control dashboard and legacy console."""
 
 from __future__ import annotations
 
-import logging
-from typing import Optional, Sequence
+import argparse
+from typing import Any, Callable, Optional, Sequence
 
-from . import core
+from . import __version__, core
+from .commands import (
+    audit,
+    autopilot as autopilot_cmd,
+    graph,
+    guard,
+    plugin,
+    rescue,
+    safe,
+    secrets,
+    sync,
+    tx,
+    wallet,
+)
+from .tui import launch_tui
+
+Handler = Callable[[argparse.Namespace], Any]
 
 
-def main(argv: Optional[Sequence[str]] = None) -> None:
-    """Launch the menu-driven interface from :mod:`gnoman.core`."""
+def _legacy_entrypoint(_args: argparse.Namespace) -> None:
+    """Invoke the legacy GNOMAN console and exit once it completes."""
 
-    args = list(argv) if argv is not None else []
-    if args:
-        raise SystemExit("GNOMAN interactive CLI does not accept command-line arguments.")
+    core.logger.info("🔁 Launching legacy console via CLI command.")
+    core.run_console()
 
-    try:
-        core.splash()
-        core.main_menu()
-    finally:
-        core.logger.info("🧹 gnoman exiting via CLI adapter.")
-        logging.shutdown()
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the top-level argument parser with every command surface."""
+
+    parser = argparse.ArgumentParser(
+        prog="gnoman",
+        description="GNOMAN mission control CLI",
+    )
+    parser.add_argument("--version", action="version", version=f"gnoman {__version__}")
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Synchronisation
+    sync_parser = subparsers.add_parser("sync", help="Synchronise secrets across environments")
+    sync_parser.add_argument("--force", action="store_true", help="Overwrite drift with highest priority values")
+    sync_parser.add_argument(
+        "--reconcile",
+        action="store_true",
+        help="Auto-reconcile drift using the AES priority order",
+    )
+    sync_parser.set_defaults(handler=sync.run)
+
+    # Safe commands
+    safe_parser = subparsers.add_parser("safe", help="Safe lifecycle operations")
+    safe_sub = safe_parser.add_subparsers(dest="safe_command")
+    safe_sub.required = True
+
+    safe_propose = safe_sub.add_parser("propose", help="Propose a Safe transaction")
+    safe_propose.add_argument("--to", required=True, help="Recipient address")
+    safe_propose.add_argument("--value", required=True, help="ETH amount to send")
+    safe_propose.add_argument("--data", default="0x", help="Transaction calldata")
+    safe_propose.set_defaults(handler=safe.propose)
+
+    safe_sign = safe_sub.add_parser("sign", help="Sign a Safe proposal")
+    safe_sign.add_argument("proposal_id", help="Proposal identifier")
+    safe_sign.set_defaults(handler=safe.sign)
+
+    safe_exec = safe_sub.add_parser("exec", help="Execute a Safe proposal")
+    safe_exec.add_argument("proposal_id", help="Proposal identifier")
+    safe_exec.set_defaults(handler=safe.exec)
+
+    safe_status = safe_sub.add_parser("status", help="Show Safe status")
+    safe_status.add_argument("safe_address", help="Safe address to inspect")
+    safe_status.set_defaults(handler=safe.status)
+
+    # Transaction commands
+    tx_parser = subparsers.add_parser("tx", help="Transaction simulation and execution")
+    tx_sub = tx_parser.add_subparsers(dest="tx_command")
+    tx_sub.required = True
+
+    tx_sim = tx_sub.add_parser("simulate", help="Simulate a Safe/DeFi transaction plan")
+    tx_sim.add_argument("proposal_id", nargs="?", help="Proposal identifier or plan reference")
+    tx_sim.add_argument("--plan", help="Path to an execution plan JSON file")
+    tx_sim.add_argument("--trace", action="store_true", help="Emit a full execution trace")
+    tx_sim.add_argument("--ml-off", action="store_true", help="Bypass the ML scorer stage")
+    tx_sim.set_defaults(handler=tx.simulate)
+
+    tx_exec = tx_sub.add_parser("exec", help="Execute a Safe proposal via tx module")
+    tx_exec.add_argument("proposal_id", help="Proposal identifier")
+    tx_exec.set_defaults(handler=tx.exec)
+
+    # Secrets commands
+    secrets_parser = subparsers.add_parser("secrets", help="Manage secrets and keyring entries")
+    secrets_sub = secrets_parser.add_subparsers(dest="secrets_command")
+    secrets_sub.required = True
+
+    secrets_list = secrets_sub.add_parser("list", help="List stored secrets")
+    secrets_list.set_defaults(handler=secrets.list_secrets)
+
+    secrets_add = secrets_sub.add_parser("add", help="Add a secret entry")
+    secrets_add.add_argument("key", help="Secret name")
+    secrets_add.add_argument("value", help="Secret value")
+    secrets_add.set_defaults(handler=secrets.add_secret)
+
+    secrets_rotate = secrets_sub.add_parser("rotate", help="Rotate a secret")
+    secrets_rotate.add_argument("key", help="Secret name")
+    secrets_rotate.set_defaults(handler=secrets.rotate_secret)
+
+    secrets_remove = secrets_sub.add_parser("rm", help="Remove a secret")
+    secrets_remove.add_argument("key", help="Secret name")
+    secrets_remove.set_defaults(handler=secrets.remove_secret)
+
+    # Audit command
+    audit_parser = subparsers.add_parser("audit", help="Generate a forensic snapshot")
+    audit_parser.set_defaults(handler=audit.run)
+
+    # Graph commands
+    graph_parser = subparsers.add_parser("graph", help="Visualise routing and liquidity graphs")
+    graph_sub = graph_parser.add_subparsers(dest="graph_command")
+    graph_sub.required = True
+
+    graph_view = graph_sub.add_parser("view", help="Render the AES graph view")
+    graph_view.add_argument(
+        "--format",
+        choices=["svg", "png", "html"],
+        default="svg",
+        help="Export format for the rendered graph",
+    )
+    graph_view.add_argument(
+        "--output",
+        help="Optional output path. Defaults to ~/.gnoman/graphs",
+    )
+    graph_view.set_defaults(handler=graph.view)
+
+    # Autopilot command
+    autopilot_parser = subparsers.add_parser("autopilot", help="Run the AES autopilot pipeline")
+    autopilot_parser.add_argument("--plan", help="Optional path to a trading plan definition")
+    autopilot_parser.add_argument("--dry-run", action="store_true", help="Simulate only without broadcast")
+    autopilot_parser.add_argument("--execute", action="store_true", help="Broadcast via Safe when complete")
+    autopilot_parser.add_argument("--alerts-only", action="store_true", help="Send alerts without execution")
+    autopilot_parser.set_defaults(handler=autopilot_cmd.run)
+
+    # Rescue command
+    rescue_parser = subparsers.add_parser("rescue", help="Incident recovery utilities")
+    rescue_sub = rescue_parser.add_subparsers(dest="rescue_command")
+    rescue_sub.required = True
+
+    rescue_safe = rescue_sub.add_parser("safe", help="Launch the Safe recovery wizard")
+    rescue_safe.add_argument("safe_address", help="Target Safe address")
+    rescue_safe.set_defaults(handler=rescue.rescue_safe)
+
+    # Rotate command
+    rotate_parser = subparsers.add_parser("rotate", help="Rotate wallets and signers")
+    rotate_sub = rotate_parser.add_subparsers(dest="rotate_command")
+    rotate_sub.required = True
+
+    rotate_all = rotate_sub.add_parser("all", help="Rotate all executor wallets and Safe owners")
+    rotate_all.set_defaults(handler=rescue.rotate_all)
+
+    # Freeze command
+    freeze_parser = subparsers.add_parser("freeze", help="Temporarily freeze a wallet or Safe")
+    freeze_parser.add_argument("target_type", choices=["wallet", "safe"], help="Entity type to freeze")
+    freeze_parser.add_argument("target_id", help="Wallet address or Safe identifier")
+    freeze_parser.add_argument(
+        "--reason",
+        default="incident response",
+        help="Reason to record in the forensic log",
+    )
+    freeze_parser.set_defaults(handler=rescue.freeze)
+
+    # Guard command
+    guard_parser = subparsers.add_parser("guard", help="Start the monitoring daemon")
+    guard_parser.add_argument(
+        "--cycles",
+        type=int,
+        default=3,
+        help="Number of monitoring cycles to execute before returning",
+    )
+    guard_parser.set_defaults(handler=guard.run)
+
+    # Plugin commands
+    plugin_parser = subparsers.add_parser("plugin", help="Manage plugins")
+    plugin_sub = plugin_parser.add_subparsers(dest="plugin_command")
+    plugin_sub.required = True
+
+    plugin_list = plugin_sub.add_parser("list", help="List installed plugins")
+    plugin_list.set_defaults(handler=plugin.list_plugins)
+
+    plugin_add = plugin_sub.add_parser("add", help="Add a plugin")
+    plugin_add.add_argument("name", help="Plugin name")
+    plugin_add.set_defaults(handler=plugin.add_plugin)
+
+    plugin_remove = plugin_sub.add_parser("remove", help="Remove a plugin")
+    plugin_remove.add_argument("name", help="Plugin name")
+    plugin_remove.set_defaults(handler=plugin.remove_plugin)
+
+    plugin_swap = plugin_sub.add_parser("swap", help="Hot-swap a plugin to a new version")
+    plugin_swap.add_argument("name", help="Plugin name to hot-swap")
+    plugin_swap.add_argument("version", help="Target plugin version")
+    plugin_swap.set_defaults(handler=plugin.swap)
+
+    # Wallet commands
+    wallet_parser = subparsers.add_parser("wallet", help="HD wallet management")
+    wallet_sub = wallet_parser.add_subparsers(dest="wallet_command")
+    wallet_sub.required = True
+
+    wallet_new = wallet_sub.add_parser("new", help="Derive a new account from the configured seed")
+    wallet_new.add_argument("--label", required=True, help="Label for the derived account")
+    wallet_new.add_argument(
+        "--path",
+        default="default",
+        help="Derivation path name or explicit template (defaults to 'default')",
+    )
+    wallet_new.set_defaults(handler=wallet.new)
+
+    wallet_list = wallet_sub.add_parser("list", help="List derived accounts")
+    wallet_list.set_defaults(handler=wallet.list_accounts)
+
+    wallet_vanity = wallet_sub.add_parser("vanity", help="Search for a vanity address")
+    wallet_vanity.add_argument("--prefix", help="Hex prefix to match (case-insensitive)")
+    wallet_vanity.add_argument("--suffix", help="Hex suffix to match (case-insensitive)")
+    wallet_vanity.add_argument("--regex", help="Regular expression to match against the address")
+    wallet_vanity.add_argument(
+        "--path",
+        default="vanity",
+        help="Derivation path name or template used during the search",
+    )
+    wallet_vanity.add_argument(
+        "--max-attempts",
+        type=int,
+        default=1_000_000,
+        help="Maximum attempts before aborting the vanity search",
+    )
+    wallet_vanity.add_argument(
+        "--log-every",
+        type=int,
+        default=5_000,
+        help="Emit a progress log every N attempts",
+    )
+    wallet_vanity.set_defaults(handler=wallet.vanity)
+
+    # Legacy command
+    legacy_parser = subparsers.add_parser("legacy", help="Launch the original GNOMAN console")
+    legacy_parser.set_defaults(handler=_legacy_entrypoint)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> Any:
+    """Entry point for ``python -m gnoman`` and ``gnoman`` console script."""
+
+    if argv is None:
+        import sys
+
+        tokens: list[str] = sys.argv[1:]
+    else:
+        tokens = list(argv)
+
+    if not tokens:
+        launch_tui()
+        return None
+
+    parser = build_parser()
+    args = parser.parse_args(tokens)
+
+    handler: Optional[Handler] = getattr(args, "handler", None)
+    if handler is None:
+        launch_tui()
+        return None
+
+    return handler(args)

--- a/gnoman/commands/__init__.py
+++ b/gnoman/commands/__init__.py
@@ -1,0 +1,16 @@
+"""CLI subcommand handlers for GNOMAN."""
+
+from . import audit, autopilot, graph, guard, plugin, rescue, safe, secrets, sync, tx  # noqa: F401
+
+__all__ = [
+    "audit",
+    "autopilot",
+    "graph",
+    "guard",
+    "plugin",
+    "rescue",
+    "safe",
+    "secrets",
+    "sync",
+    "tx",
+]

--- a/gnoman/commands/audit.py
+++ b/gnoman/commands/audit.py
@@ -1,0 +1,112 @@
+"""Forensic audit command implementation."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+from ..utils import aes, logbook
+
+AUDIT_DIR = Path.home() / ".gnoman" / "audits"
+
+
+def run(args) -> Dict[str, object]:
+    collector = aes.get_audit_collector()
+    signer = aes.get_audit_signer()
+
+    payload = collector.collect()
+    signature = signer.sign(payload)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+    AUDIT_DIR.mkdir(parents=True, exist_ok=True)
+    json_path = AUDIT_DIR / f"audit-{timestamp}.json"
+    pdf_path = AUDIT_DIR / f"audit-{timestamp}.pdf"
+
+    report = {"payload": payload, "signature": signature}
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    _write_pdf(pdf_path, payload, signature, timestamp)
+
+    record = {
+        "action": "audit_snapshot",
+        "status": "generated",
+        "json_path": str(json_path),
+        "pdf_path": str(pdf_path),
+        "signature": signature,
+    }
+    logbook.info(record)
+    print(f"[AUDIT] Report written to {json_path}")
+    print(f"[AUDIT] Signed PDF stored at {pdf_path}")
+    return record
+
+
+def _write_pdf(path: Path, payload: Dict[str, object], signature: str, timestamp: str) -> None:
+    lines: List[str] = [
+        f"GNOMAN Forensic Audit — {timestamp}Z",
+        "", "Wallets:",
+    ]
+    for wallet in payload.get("wallets", []):
+        lines.append(
+            f"  {wallet['name']} {wallet['address']} — balance {wallet['balance']} ETH"
+        )
+    lines.append("")
+    lines.append("Safes:")
+    for safe in payload.get("safes", []):
+        owners = ", ".join(safe.get("owners", []))
+        lines.append(
+            f"  {safe['address']} threshold={safe.get('threshold')} owners=[{owners}]"
+        )
+    lines.append("")
+    lines.append("Expiring secrets:")
+    for secret in payload.get("expiring_secrets", []):
+        lines.append(
+            f"  {secret['key']} expires in {secret['expires_in_days']} days"
+        )
+    lines.append("")
+    lines.append(f"Signature: {signature}")
+
+    pdf_bytes = _build_pdf(lines)
+    path.write_bytes(pdf_bytes)
+
+
+def _build_pdf(lines: List[str]) -> bytes:
+    def esc(text: str) -> str:
+        return text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    header = "%PDF-1.4\n"
+    obj1 = "1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj\n"
+    obj2 = "2 0 obj<< /Type /Pages /Count 1 /Kids[3 0 R] >>endobj\n"
+    obj3 = (
+        "3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox[0 0 612 792] "
+        "/Resources<< /Font<< /F1 5 0 R >> >> /Contents 4 0 R >>endobj\n"
+    )
+    cursor_y = 760
+    content_segments: List[str] = []
+    for line in lines:
+        content_segments.append(f"BT /F1 12 Tf 72 {cursor_y} Td ({esc(line)}) Tj ET\n")
+        cursor_y -= 16
+    stream = "".join(content_segments)
+    stream_bytes = stream.encode("utf-8")
+    obj4 = f"4 0 obj<< /Length {len(stream_bytes)} >>stream\n{stream}endstream\nendobj\n"
+    obj5 = "5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj\n"
+
+    parts = [header, obj1, obj2, obj3, obj4, obj5]
+    encoded_parts = [part.encode("utf-8") for part in parts]
+
+    offsets: List[int] = []
+    position = len(encoded_parts[0])
+    for part in encoded_parts[1:]:
+        offsets.append(position)
+        position += len(part)
+    offsets = [0] + offsets  # object 0 placeholder
+
+    xref_offset = sum(len(part) for part in encoded_parts)
+    xref_lines = ["xref\n", "0 6\n", "0000000000 65535 f \n"]
+    for off in offsets[1:]:
+        xref_lines.append(f"{off:010d} 00000 n \n")
+    xref = "".join(xref_lines)
+    trailer = "trailer<< /Size 6 /Root 1 0 R >>\n"
+    startxref = f"startxref\n{xref_offset}\n%%EOF\n"
+
+    return b"".join(encoded_parts + [xref.encode("utf-8"), trailer.encode("utf-8"), startxref.encode("utf-8")])

--- a/gnoman/commands/autopilot.py
+++ b/gnoman/commands/autopilot.py
@@ -1,0 +1,28 @@
+"""Autopilot orchestration command."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..utils import aes, logbook
+
+
+def run(args) -> Dict[str, object]:
+    orchestrator = aes.get_autopilot()
+    result = orchestrator.execute(
+        plan_path=getattr(args, "plan", None),
+        dry_run=bool(getattr(args, "dry_run", False)),
+        execute=bool(getattr(args, "execute", False)),
+        alerts_only=bool(getattr(args, "alerts_only", False)),
+    )
+    record = {
+        "action": "autopilot",
+        "mode": result["mode"],
+        "steps": result["steps"],
+        "plugin_versions": result["plugin_versions"],
+    }
+    logbook.info(record)
+    for step in result["steps"]:
+        print(f"[AUTOPILOT] {step['name']}: {step['status']}")
+    print(f"[AUTOPILOT] Mode: {result['mode']}")
+    return record

--- a/gnoman/commands/graph.py
+++ b/gnoman/commands/graph.py
@@ -1,0 +1,21 @@
+"""Graph visualisation command handlers."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..utils import aes, logbook
+
+
+def view(args) -> Dict[str, object]:
+    manager = aes.get_graph_manager()
+    result = manager.render(args.format, getattr(args, "output", None))
+    record = {
+        "action": "graph_view",
+        "format": result["format"],
+        "path": result["path"],
+        "highlighted": result["highlighted_routes"],
+    }
+    logbook.info(record)
+    print(f"[GRAPH] Rendered {result['format']} graph → {result['path']}")
+    return record

--- a/gnoman/commands/guard.py
+++ b/gnoman/commands/guard.py
@@ -1,0 +1,31 @@
+"""Guard monitoring command implementation."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..utils import aes, logbook
+
+
+def run(args) -> Dict[str, object]:
+    guardian = aes.get_guardian()
+    result = guardian.run(int(getattr(args, "cycles", 3)))
+    record = {
+        "action": "guard_start",
+        "status": "completed",
+        "cycles": result["cycles"],
+        "alerts": result["alerts"],
+        "channels": result["alert_channels"],
+    }
+    logbook.info(record)
+    for cycle in result["cycles"]:
+        print(
+            "[GUARD] cycle="
+            f"{cycle['timestamp']} secrets={'ok' if cycle['secrets_ok'] else 'drift'} "
+            f"gas={cycle['gas_gwei']} gwei routes={len(cycle['profitable_routes'])}"
+        )
+    if result["alerts"]:
+        print(f"[GUARD] Alerts dispatched via {', '.join(result['alert_channels'])}")
+    else:
+        print("[GUARD] No alerts raised.")
+    return record

--- a/gnoman/commands/plugin.py
+++ b/gnoman/commands/plugin.py
@@ -1,0 +1,76 @@
+"""Plugin management command handlers."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..utils import aes, logbook
+
+
+def _registry() -> aes.PluginRegistry:
+    return aes.get_plugin_registry()
+
+
+def list_plugins(args) -> Dict[str, List[Dict[str, object]]]:
+    plugins = _registry().list()
+    record = {
+        "action": "plugin_list",
+        "plugins": plugins,
+        "status": "ok",
+    }
+    logbook.info(record)
+    names = ", ".join(f"{entry['name']}@{entry['version']}" for entry in plugins)
+    print(f"[PLUGIN] Installed plugins: {names}")
+    return record
+
+
+def add_plugin(args) -> Dict[str, object]:
+    entry = _registry().add(args.name)
+    record = {
+        "action": "plugin_add",
+        "plugin": entry,
+        "status": "registered",
+    }
+    logbook.info(record)
+    print(f"[PLUGIN] Added {entry['name']} ({entry['version']})")
+    return record
+
+
+def remove_plugin(args) -> Dict[str, object]:
+    entry = _registry().remove(args.name)
+    record = {
+        "action": "plugin_remove",
+        "plugin": entry,
+    }
+    logbook.info(record)
+    status = "removed" if entry.get("removed") else "missing"
+    print(f"[PLUGIN] {args.name} {status}.")
+    return record
+
+
+def swap(args) -> Dict[str, object]:
+    try:
+        entry = _registry().swap(args.name, args.version)
+    except ValueError as exc:  # pragma: no cover - interactive error path
+        record = {
+            "action": "plugin_swap",
+            "plugin": args.name,
+            "status": "error",
+            "error": str(exc),
+        }
+        logbook.info(record)
+        print(f"[PLUGIN] Swap failed: {exc}")
+        return record
+
+    record = {
+        "action": "plugin_swap",
+        "plugin": entry,
+        "status": "swapped",
+    }
+    logbook.info(record)
+    print(
+        "[PLUGIN] Swapped {name} {prev} → {version}".format(
+            name=entry["name"], prev=entry["previous_version"], version=entry["version"]
+        )
+    )
+    return record

--- a/gnoman/commands/rescue.py
+++ b/gnoman/commands/rescue.py
@@ -1,0 +1,52 @@
+"""Incident recovery command handlers."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..utils import aes, logbook
+
+
+def rescue_safe(args) -> Dict[str, object]:
+    manager = aes.get_recovery_manager()
+    result = manager.start_safe_recovery(args.safe_address)
+    record = {
+        "action": "rescue_safe",
+        "safe": result["safe"],
+        "steps": result["steps"],
+        "status": result["status"],
+    }
+    logbook.info(record)
+    print(f"[RESCUE] Recovery wizard started for {result['safe']}")
+    for step in result["steps"]:
+        print(f"  • {step}")
+    return record
+
+
+def rotate_all(args=None) -> Dict[str, object]:
+    manager = aes.get_recovery_manager()
+    result = manager.rotate_all()
+    record = {
+        "action": "rotate_all",
+        "timestamp": result["timestamp"],
+        "owners": result["owners"],
+        "status": result["status"],
+    }
+    logbook.info(record)
+    print("[ROTATE] Executor wallets rotated and Safe owners updated.")
+    return record
+
+
+def freeze(args) -> Dict[str, object]:
+    manager = aes.get_recovery_manager()
+    result = manager.freeze(args.target_type, args.target_id, args.reason)
+    record = {
+        "action": "freeze",
+        "target_type": result["target_type"],
+        "target_id": result["target_id"],
+        "reason": result["reason"],
+        "unfreeze_token": result["unfreeze_token"],
+    }
+    logbook.info(record)
+    print(f"[FREEZE] {result['target_type']} {result['target_id']} frozen. Token={result['unfreeze_token']}")
+    return record

--- a/gnoman/commands/safe.py
+++ b/gnoman/commands/safe.py
@@ -1,0 +1,59 @@
+"""Handlers for Safe lifecycle commands."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..utils import aes, logbook
+
+
+_DEF_SAFE = "0xSAFECORE"
+
+
+def _registry() -> aes.SafeRegistry:
+    return aes.get_safe_registry()
+
+
+def propose(args) -> Dict[str, object]:
+    proposal = _registry().propose(args.to, args.value, args.data or "0x")
+    record = {
+        "action": "safe_propose",
+        "safe": _DEF_SAFE,
+        "proposal": proposal,
+    }
+    logbook.info(record)
+    print(f"[SAFE] Proposed tx #{proposal['id']} to {proposal['to']} value={proposal['value']}")
+    return record
+
+
+def sign(args) -> Dict[str, object]:
+    proposal = _registry().sign(args.proposal_id)
+    record = {
+        "action": "safe_sign",
+        "proposal": proposal,
+    }
+    logbook.info(record)
+    print(f"[SAFE] Signed proposal {proposal['id']} status={proposal['status']}")
+    return record
+
+
+def exec(args) -> Dict[str, object]:
+    proposal = _registry().execute(args.proposal_id)
+    record = {
+        "action": "safe_exec",
+        "proposal": proposal,
+    }
+    logbook.info(record)
+    print(f"[SAFE] Executed proposal {proposal['id']} status={proposal['status']}")
+    return record
+
+
+def status(args) -> Dict[str, object]:
+    info = _registry().status(args.safe_address)
+    record = {
+        "action": "safe_status",
+        "safe": info,
+    }
+    logbook.info(record)
+    print(f"[SAFE] Status for {info['address']}: threshold={info.get('threshold')} owners={len(info.get('owners', []))}")
+    return record

--- a/gnoman/commands/secrets.py
+++ b/gnoman/commands/secrets.py
@@ -1,0 +1,81 @@
+"""Keyring and environment management commands."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..utils import aes, logbook
+
+MASK = "***"
+
+
+def _coordinator() -> aes.SecretsSyncCoordinator:
+    return aes.get_secrets_coordinator()
+
+
+def list_secrets(args) -> Dict[str, List[Dict[str, object]]]:
+    coordinator = _coordinator()
+    snapshot = coordinator.snapshot()
+    entries: List[Dict[str, object]] = []
+    for key in coordinator.keys():
+        values = {store: store_values.get(key) for store, store_values in snapshot.items() if key in store_values}
+        status = "ok" if len(set(values.values())) == 1 else "drift"
+        meta = coordinator.metadata(key)
+        entries.append(
+            {
+                "key": key,
+                "status": status,
+                "sources": list(values.keys()),
+                "expires_at": meta.get("expires_at"),
+            }
+        )
+    record = {
+        "action": "secrets_list",
+        "entries": entries,
+        "status": "ok",
+    }
+    logbook.info(record)
+    print(f"[SECRETS] {len(entries)} secrets tracked. Drift keys: {[e['key'] for e in entries if e['status'] == 'drift']}")
+    return record
+
+
+def add_secret(args) -> Dict[str, object]:
+    coordinator = _coordinator()
+    coordinator.set_secret(args.key, args.value)
+    record = {
+        "action": "secrets_add",
+        "key": args.key,
+        "value": MASK,
+        "status": "stored",
+    }
+    logbook.info(record)
+    print(f"[SECRETS] Added key {args.key}")
+    return record
+
+
+def rotate_secret(args) -> Dict[str, object]:
+    coordinator = _coordinator()
+    new_value = coordinator.rotate_secret(args.key)
+    record = {
+        "action": "secrets_rotate",
+        "key": args.key,
+        "value": MASK,
+        "status": "rotated",
+        "preview": new_value[:4] + MASK,
+    }
+    logbook.info(record)
+    print(f"[SECRETS] Rotated key {args.key}")
+    return record
+
+
+def remove_secret(args) -> Dict[str, object]:
+    coordinator = _coordinator()
+    coordinator.remove_secret(args.key)
+    record = {
+        "action": "secrets_remove",
+        "key": args.key,
+        "status": "removed",
+    }
+    logbook.info(record)
+    print(f"[SECRETS] Removed key {args.key}")
+    return record

--- a/gnoman/commands/sync.py
+++ b/gnoman/commands/sync.py
@@ -1,0 +1,63 @@
+"""Synchronise GNOMAN secrets across environments."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from ..utils import aes, logbook
+
+
+def run(args) -> Dict[str, object]:
+    coordinator = aes.get_secrets_coordinator()
+    snapshot = coordinator.snapshot()
+    drift = coordinator.detect_drift(snapshot)
+
+    if not drift:
+        record = {
+            "action": "sync",
+            "status": "in-sync",
+            "drift": {},
+        }
+        logbook.info(record)
+        print("[SYNC] All stores already aligned.")
+        return record
+
+    mode = "inspect"
+    operations: List[Dict[str, object]] = []
+
+    if args.force:
+        operations = coordinator.force_sync()
+        mode = "force"
+        print("[SYNC] Forced priority sync applied.")
+    elif args.reconcile:
+        operations = coordinator.reconcile_priority()
+        mode = "priority"
+        print("[SYNC] Drift reconciled using AES priority order.")
+    else:
+        print("[SYNC] Drift detected. Enter store to reconcile each key (leave blank for priority store).")
+        decisions: Dict[str, Tuple[str, str]] = {}
+        for key, stores in drift.items():
+            priority_store, priority_value = coordinator.authoritative_value(key)
+            options = ", ".join(f"{name}={value}" for name, value in stores.items())
+            prompt = f"  - {key} ({options}) [{priority_store}]: "
+            chosen_store = input(prompt).strip()  # noqa: PLW1508 - interactive prompt intentional
+            if chosen_store not in stores:
+                chosen_store = priority_store or next(iter(stores.keys()))
+            chosen_value = stores.get(chosen_store, priority_value or "")
+            decisions[key] = (chosen_store or "unknown", chosen_value)
+        operations = coordinator.apply_decisions(decisions)
+        mode = "interactive"
+        print("[SYNC] Manual reconciliation complete.")
+
+    reconciled = coordinator.snapshot()
+    record = {
+        "action": "sync",
+        "status": "reconciled",
+        "mode": mode,
+        "drift": drift,
+        "operations": operations,
+        "result": reconciled,
+    }
+    logbook.info(record)
+    print(f"[SYNC] Keys harmonised across {len(reconciled)} stores.")
+    return record

--- a/gnoman/commands/tx.py
+++ b/gnoman/commands/tx.py
@@ -1,0 +1,59 @@
+"""Transaction simulation and execution handlers."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict
+
+from ..utils import aes, logbook
+
+
+def simulate(args) -> Dict[str, object]:
+    engine = aes.get_simulation_engine()
+    result = engine.simulate(
+        proposal_id=getattr(args, "proposal_id", None),
+        plan_path=getattr(args, "plan", None),
+        trace=bool(getattr(args, "trace", False)),
+        ml_enabled=not bool(getattr(args, "ml_off", False)),
+    )
+    record = {
+        "action": "tx_simulate",
+        "proposal_id": result["proposal_id"],
+        "plan_digest": result["plan_digest"],
+        "gas_used": result["gas_used"],
+        "success": result["success"],
+        "revert_reason": result["revert_reason"],
+        "ml_score": result["ml_score"],
+        "trace": result["trace"],
+    }
+    logbook.info(record)
+    status = "ok" if result["success"] else f"reverted ({result['revert_reason']})"
+    print(f"[TX] Simulation {result['plan_digest']} gas={result['gas_used']} status={status}")
+    if result["trace"]:
+        print("[TX] Trace:")
+        for line in result["trace"]:
+            print(f"    {line}")
+    if result["ml_score"] is not None:
+        print(f"[TX] ML score: {result['ml_score']}")
+    return record
+
+
+def exec(args) -> Dict[str, object]:
+    payload_path = Path.home() / ".gnoman" / "queued" / f"{args.proposal_id}.json"
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "proposal_id": args.proposal_id,
+        "broadcast_at": int(time.time()),
+    }
+    payload_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    record = {
+        "action": "tx_exec",
+        "proposal_id": args.proposal_id,
+        "status": "queued",
+        "payload_path": str(payload_path),
+    }
+    logbook.info(record)
+    print(f"[TX] Execution payload queued at {payload_path}")
+    return record

--- a/gnoman/commands/wallet.py
+++ b/gnoman/commands/wallet.py
@@ -1,0 +1,86 @@
+"""Command handlers for the wallet subsystem."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Dict, List, Optional
+
+from ..utils import logbook
+from ..wallet import (
+    DerivationResolver,
+    WalletManager,
+    WalletManagerError,
+    WalletSeedError,
+    WalletSeedManager,
+)
+
+_MANAGER: Optional[WalletManager] = None
+
+
+def _service_name() -> str:
+    return os.getenv("GNOMAN_KEYRING_SERVICE", "gnoman")
+
+
+def _manager() -> WalletManager:
+    global _MANAGER
+    if _MANAGER is None:
+        try:
+            seed_manager = WalletSeedManager(service_name=_service_name())
+        except WalletSeedError as exc:
+            raise SystemExit(str(exc)) from exc
+        resolver = DerivationResolver()
+        _MANAGER = WalletManager(seed_manager=seed_manager, resolver=resolver)
+    return _MANAGER
+
+
+def new(args) -> Dict[str, object]:
+    manager = _manager()
+    try:
+        record = manager.create_account(args.label, path=args.path)
+    except WalletManagerError as exc:
+        raise SystemExit(str(exc)) from exc
+    payload = asdict(record)
+    logbook.info({"action": "wallet_new", "label": record.label, "address": record.address, "path": record.derivation_path})
+    print(f"[WALLET] {record.label} -> {record.address} ({record.derivation_path})")
+    return payload
+
+
+def list_accounts(args) -> Dict[str, List[Dict[str, object]]]:
+    manager = _manager()
+    records = [asdict(record) for record in manager.list_accounts()]
+    logbook.info({"action": "wallet_list", "count": len(records)})
+    for rec in records:
+        print(f"[WALLET] {rec['label']} -> {rec['address']} ({rec['derivation_path']})")
+    return {"accounts": records}
+
+
+def vanity(args) -> Dict[str, object]:
+    manager = _manager()
+    try:
+        record = manager.find_vanity(
+            prefix=args.prefix,
+            suffix=args.suffix,
+            regex=args.regex,
+            path=args.path,
+            max_attempts=args.max_attempts,
+            log_every=args.log_every,
+        )
+    except WalletManagerError as exc:
+        raise SystemExit(str(exc)) from exc
+    payload = asdict(record)
+    logbook.info(
+        {
+            "action": "wallet_vanity",
+            "address": record.address,
+            "path": record.derivation_path,
+            "index": record.index,
+            "prefix": args.prefix,
+            "suffix": args.suffix,
+            "regex": args.regex,
+        }
+    )
+    print(
+        f"[WALLET] Vanity match {record.address} ({record.derivation_path}, index={record.index})"
+    )
+    return payload

--- a/gnoman/core.py
+++ b/gnoman/core.py
@@ -915,12 +915,19 @@ def main_menu() -> None:  # L1001
             print(f"Error: {e}. See gnoman.log.")
 
 
-# ───────── Entrypoint ─────────  # L1030
-if __name__ == "__main__":
+def run_console(*, shutdown_logging: bool = True) -> None:
+    """Launch the legacy splash screen and interactive menu."""
+
     try:
         splash()
         main_menu()
     finally:
-        logger.info("🧹 gnoman exiting.")
-        logging.shutdown()
+        logger.info("🧹 gnoman exiting via legacy console helper.")
+        if shutdown_logging:
+            logging.shutdown()
+
+
+# ───────── Entrypoint ─────────  # L1030
+if __name__ == "__main__":
+    run_console()
 # EOF  # L1038

--- a/gnoman/tui.py
+++ b/gnoman/tui.py
@@ -1,0 +1,1316 @@
+"""Curses TUI scaffolding for GNOMAN mission control."""
+
+from __future__ import annotations
+
+import curses
+import io
+from contextlib import redirect_stdout
+from dataclasses import dataclass, field
+from datetime import datetime
+from textwrap import wrap
+from types import SimpleNamespace
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from . import core
+from .commands import (
+    audit as audit_cmd,
+    autopilot as autopilot_cmd,
+    graph as graph_cmd,
+    guard as guard_cmd,
+    plugin as plugin_cmd,
+    rescue as rescue_cmd,
+    safe as safe_cmd,
+    secrets as secrets_cmd,
+    sync as sync_cmd,
+    tx as tx_cmd,
+)
+from .utils import aes, logbook
+
+MIN_HEIGHT = 18
+MIN_WIDTH = 70
+
+MenuItem = Dict[str, object]
+
+MenuCallback = Callable[["MenuContext"], Optional[Sequence[str]]]
+MenuEntry = Tuple[str, Optional[MenuCallback]]
+MenuBuilder = Callable[["MenuContext"], Sequence[MenuEntry]]
+
+MENU_ITEMS: List[MenuItem] = [
+    {
+        "key": "S",
+        "title": "Safe",
+        "tagline": "Coordinate Safe proposals and signature flow.",
+        "description": (
+            "Draft, sign, and execute Safe transactions while keeping quorum "
+            "thresholds and owner health front of mind."
+        ),
+        "commands": [
+            "gnoman safe propose --to <addr> --value <eth> --data <calldata>",
+            "gnoman safe sign <proposal-id>",
+            "gnoman safe exec <proposal-id>",
+        ],
+    },
+    {
+        "key": "T",
+        "title": "Tx",
+        "tagline": "Simulate execution and broadcast confidently.",
+        "description": (
+            "Build Safe payloads, simulate strategies against an Anvil fork, "
+            "and execute pre-cleared proposals with traceability."
+        ),
+        "commands": [
+            "gnoman tx simulate [<proposal-id>] [--plan plan.json]",
+            "gnoman tx exec <proposal-id>",
+            "gnoman tx simulate --trace",
+        ],
+    },
+    {
+        "key": "C",
+        "title": "Secrets",
+        "tagline": "Manage encrypted keyrings and vault entries.",
+        "description": (
+            "Rotate operator secrets, inspect stored credentials, and keep "
+            "sensitive material in sync across environments."
+        ),
+        "commands": [
+            "gnoman secrets list",
+            "gnoman secrets add <KEY> <VALUE>",
+            "gnoman secrets rotate <KEY>",
+        ],
+    },
+    {
+        "key": "Y",
+        "title": "Sync",
+        "tagline": "Reconcile .env, vault, and local state.",
+        "description": (
+            "Detect drift between secure storage, local secrets, and runtime "
+            "configuration then reconcile it interactively or forcefully."
+        ),
+        "commands": [
+            "gnoman sync",
+            "gnoman sync --reconcile",
+            "gnoman sync --force",
+        ],
+    },
+    {
+        "key": "A",
+        "title": "Audit",
+        "tagline": "Snapshot state for forensic record keeping.",
+        "description": (
+            "Generate signed JSON and PDF audit bundles detailing current "
+            "balances, signers, and operational posture."
+        ),
+        "commands": [
+            "gnoman audit",
+        ],
+    },
+    {
+        "key": "G",
+        "title": "Graph",
+        "tagline": "Visualise routing and liquidity insights.",
+        "description": (
+            "Render AES route graphs to SVG, PNG, or HTML to investigate "
+            "liquidity flows and profitable pathways."
+        ),
+        "commands": [
+            "gnoman graph view --format svg",
+            "gnoman graph view --output custom/path",
+        ],
+    },
+    {
+        "key": "U",
+        "title": "Autopilot",
+        "tagline": "Assemble and validate the AES trading pipeline.",
+        "description": (
+            "Fetch loans, build trades, run ML validation, and queue or "
+            "broadcast Safe payloads directly from mission control."
+        ),
+        "commands": [
+            "gnoman autopilot --plan plan.json",
+            "gnoman autopilot --dry-run",
+            "gnoman autopilot --execute",
+        ],
+    },
+    {
+        "key": "R",
+        "title": "Rescue",
+        "tagline": "Guide incident response and safe recovery.",
+        "description": (
+            "Launch Safe recovery workflows, rotate signers, and freeze "
+            "compromised wallets until a coordinated unfreeze."
+        ),
+        "commands": [
+            "gnoman rescue safe <SAFE_ADDR>",
+            "gnoman rotate all",
+            "gnoman freeze <wallet|safe> <id>",
+        ],
+    },
+    {
+        "key": "P",
+        "title": "Plugins",
+        "tagline": "Curate optional integrations and tooling.",
+        "description": (
+            "List, install, remove, and hot-swap plugin packages while "
+            "maintaining a forensic history of version changes."
+        ),
+        "commands": [
+            "gnoman plugin list",
+            "gnoman plugin add <name>",
+            "gnoman plugin swap <name> <version>",
+        ],
+    },
+    {
+        "key": "D",
+        "title": "Guard",
+        "tagline": "Keep an eye on balances, quorum, and alerts.",
+        "description": (
+            "Run the System Guardian daemon to monitor gas, balances, "
+            "thresholds, and arbitrage alerts on a cadence."
+        ),
+        "commands": [
+            "gnoman guard",
+            "gnoman guard --cycles 5",
+        ],
+    },
+    {
+        "key": "L",
+        "title": "Legacy",
+        "tagline": "Access the original GNOMAN console menus.",
+        "description": (
+            "Launch the legacy splash screen and menu-driven interface to operate "
+            "Safe, wallet, and key manager workflows exactly as before."
+        ),
+        "commands": [
+            "gnoman legacy",
+            "Mission Control › Legacy Console",
+        ],
+        "mode": "legacy",
+    },
+]
+
+KEY_TO_INDEX = {
+    ord(item["key"].lower()): idx for idx, item in enumerate(MENU_ITEMS)
+}
+KEY_TO_INDEX.update({ord(item["key"]): idx for idx, item in enumerate(MENU_ITEMS)})
+
+QUIT_KEYS = {ord("q"), ord("Q"), 27}
+ENTER_KEYS = {curses.KEY_ENTER, ord("\n"), ord("\r")}
+
+DEFAULT_SAFE = "0xSAFECORE"
+
+
+@dataclass
+class MenuContext:
+    """Runtime context shared between nested menus."""
+
+    stdscr: "curses._CursesWindow"
+    palette: Dict[str, int]
+    stack: List[str] = field(default_factory=list)
+    current_menu: str = ""
+
+
+def _serialize(value: object) -> object:
+    """Make ``value`` JSON-serialisable for forensic logging."""
+
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_serialize(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _serialize(item) for key, item in value.items()}
+    return str(value)
+
+
+def _menu_log(action: str, **fields: object) -> None:
+    """Emit a forensic menu log entry with ``action`` and ``fields``."""
+
+    timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    payload = {key: _serialize(value) for key, value in fields.items()}
+    details = " ".join(f"{key}={payload[key]}" for key in sorted(payload))
+    message = f"[GNOMAN.Menu] {action}"
+    if details:
+        message = f"{message} {details}"
+    record = {
+        "timestamp": timestamp,
+        "channel": "GNOMAN.Menu",
+        "action": action,
+        **payload,
+        "message": message,
+    }
+    logbook.info(record)
+
+
+def _key_repr(key: int) -> str:
+    """Return a printable representation for ``key``."""
+
+    if 0 <= key < 256:
+        char = chr(key)
+        if char.isprintable():
+            return char
+    return str(key)
+
+
+def _wrap_text(text: str, width: int) -> List[str]:
+    """Wrap ``text`` for the available ``width`` guarding against small panes."""
+
+    if width <= 0:
+        return []
+    return wrap(text, width)
+
+
+def _safe_addstr(win: "curses._CursesWindow", y: int, x: int, text: str, attr: int = 0) -> None:
+    """Safely add ``text`` at ``(y, x)`` without raising ``curses.error``."""
+
+    max_y, max_x = win.getmaxyx()
+    if y < 0 or x < 0 or y >= max_y or x >= max_x:
+        return
+    available = max_x - x
+    if available <= 0:
+        return
+    snippet = text[:available]
+    try:
+        win.addstr(y, x, snippet, attr)
+    except curses.error:
+        # Some terminals are strict about drawing on the bottom-right cell.
+        pass
+
+
+def _render_resize_hint(stdscr: "curses._CursesWindow", palette: Dict[str, int]) -> None:
+    """Render a hint asking the operator to enlarge their terminal."""
+
+    height, width = stdscr.getmaxyx()
+    stdscr.erase()
+    message = "GNOMAN needs at least 70x18 to render the dashboard."
+    hint = "Resize your terminal or press Q to exit."
+    row = max(0, height // 2 - 1)
+    msg_col = max(0, (width - len(message)) // 2)
+    hint_col = max(0, (width - len(hint)) // 2)
+    _safe_addstr(stdscr, row, msg_col, message, palette["title"])
+    _safe_addstr(stdscr, row + 2, hint_col, hint, palette["footer"])
+    stdscr.refresh()
+
+
+def _render_dashboard(
+    stdscr: "curses._CursesWindow", selected: int, palette: Dict[str, int]
+) -> bool:
+    """Render the mission control dashboard."""
+
+    stdscr.erase()
+    height, width = stdscr.getmaxyx()
+
+    if height < MIN_HEIGHT or width < MIN_WIDTH:
+        _render_resize_hint(stdscr, palette)
+        return False
+
+    active = MENU_ITEMS[selected]
+    menu_x = 2
+    menu_width = max(24, min(32, width // 3 + 2))
+    detail_x = menu_x + menu_width + 2
+    detail_width = width - detail_x - 2
+    separator_y = height - 4
+    detail_limit = separator_y
+
+    # Header
+    _safe_addstr(stdscr, 0, 2, "GNOMAN Mission Control", palette["title"])
+    version = "v0.3.0"
+    _safe_addstr(stdscr, 0, max(2, width - len(version) - 2), version, palette["subtitle"])
+    _safe_addstr(stdscr, 1, 2, "Guardian of Safes, Master of Keys", palette["subtitle"])
+    if width > 2:
+        _safe_addstr(stdscr, 2, 1, "-" * (width - 2), palette["subtitle"])
+
+    # Menu column
+    _safe_addstr(stdscr, 3, menu_x, "Modules", palette["detail_heading"])
+    for idx, item in enumerate(MENU_ITEMS):
+        y = 4 + idx
+        if y >= detail_limit:
+            break
+        label = f"[{item['key']}] {item['title']}"
+        padded = label[:menu_width].ljust(menu_width)
+        _safe_addstr(stdscr, y, menu_x, " " * menu_width)
+        if idx == selected:
+            _safe_addstr(stdscr, y, menu_x, padded, palette["menu_active"])
+        else:
+            _safe_addstr(stdscr, y, menu_x, padded, palette["menu_inactive"])
+            _safe_addstr(stdscr, y, menu_x + 1, item["key"], palette["menu_key"])
+
+    # Divider between menu and detail panes
+    divider_x = detail_x - 1
+    for y in range(3, separator_y):
+        _safe_addstr(stdscr, y, divider_x, "|", palette["subtitle"])
+
+    # Detail pane
+    detail_y = 3
+    _safe_addstr(
+        stdscr,
+        detail_y,
+        detail_x,
+        f"{active['title']} module",
+        palette["detail_heading"],
+    )
+    detail_y += 1
+    for line in _wrap_text(str(active["description"]), detail_width):
+        if detail_y >= detail_limit:
+            break
+        _safe_addstr(stdscr, detail_y, detail_x, line, palette["detail_text"])
+        detail_y += 1
+
+    commands = [str(cmd) for cmd in active.get("commands", [])]
+    if commands and detail_y < detail_limit - 1:
+        _safe_addstr(stdscr, detail_y, detail_x, "Key commands:", palette["detail_heading"])
+        detail_y += 1
+        for cmd in commands:
+            if detail_y >= detail_limit:
+                break
+            wrapped = _wrap_text(cmd, detail_width - 4)
+            if not wrapped:
+                continue
+            _safe_addstr(
+                stdscr,
+                detail_y,
+                detail_x,
+                f"- {wrapped[0]}",
+                palette["detail_text"],
+            )
+            detail_y += 1
+            for continuation in wrapped[1:]:
+                if detail_y >= detail_limit:
+                    break
+                _safe_addstr(
+                    stdscr,
+                    detail_y,
+                    detail_x + 2,
+                    continuation,
+                    palette["detail_text"],
+                )
+                detail_y += 1
+
+    if separator_y < height and width > 2:
+        _safe_addstr(stdscr, separator_y, 1, "-" * (width - 2), palette["subtitle"])
+
+    # Status and footer
+    status_width = max(0, width - 4)
+    status_y = max(0, height - 3)
+    if status_width > 0 and 0 <= status_y < height:
+        _safe_addstr(stdscr, status_y, 2, " " * status_width)
+        status_text = f"Active module: {active['title']} — {active['tagline']}"
+        _safe_addstr(stdscr, status_y, 2, status_text[:status_width], palette["status"])
+
+    footer_y = max(0, height - 2)
+    if status_width > 0 and 0 <= footer_y < height and footer_y > status_y:
+        footer_text = "Use arrow keys or hotkeys to explore • Press Q to exit"
+        _safe_addstr(stdscr, footer_y, 2, " " * status_width)
+        _safe_addstr(stdscr, footer_y, 2, footer_text[:status_width], palette["footer"])
+
+    stdscr.refresh()
+    return True
+
+
+def _clear_input_line(ctx: MenuContext) -> None:
+    """Blank the interactive input row for ``ctx``."""
+
+    height, width = ctx.stdscr.getmaxyx()
+    y = max(0, height - 4)
+    _safe_addstr(ctx.stdscr, y, 0, " " * max(0, width))
+
+
+def _render_submenu(
+    ctx: MenuContext,
+    title: str,
+    items: Sequence[MenuEntry],
+    selected: int,
+    status_lines: Sequence[str],
+) -> bool:
+    """Render a submenu screen and return ``True`` when interactions allowed."""
+
+    stdscr = ctx.stdscr
+    palette = ctx.palette
+    stdscr.erase()
+    height, width = stdscr.getmaxyx()
+
+    if height < MIN_HEIGHT or width < MIN_WIDTH:
+        _render_resize_hint(stdscr, palette)
+        return False
+
+    header = ctx.current_menu or title
+    _safe_addstr(stdscr, 0, 2, header[: max(0, width - 4)], palette["title"])
+    hint = "Use arrows or numbers to move • Press Enter to select"
+    _safe_addstr(stdscr, 1, 2, hint[: max(0, width - 4)], palette["subtitle"])
+
+    menu_start = 3
+    total = len(items)
+    for idx, (label, _) in enumerate(items):
+        prefix = "0" if idx == total - 1 and label.lower().startswith("back") else f"{idx + 1}"
+        text = f"{prefix}. {label}"
+        attr = palette["menu_active"] if idx == selected else palette["menu_inactive"]
+        _safe_addstr(stdscr, menu_start + idx, 4, " " * max(0, width - 8))
+        _safe_addstr(stdscr, menu_start + idx, 4, text[: max(0, width - 8)], attr)
+
+    status_y = menu_start + total + 1
+    bottom_limit = height - 5
+    if status_lines and status_y <= bottom_limit:
+        _safe_addstr(stdscr, status_y, 4, "Last action:", palette["detail_heading"])
+        status_y += 1
+        for line in status_lines:
+            for wrapped in _wrap_text(str(line), max(0, width - 10)):
+                if status_y > bottom_limit:
+                    break
+                _safe_addstr(stdscr, status_y, 6, wrapped, palette["detail_text"])
+                status_y += 1
+
+    footer_y = height - 2
+    footer_text = "Press [q] to return"
+    _safe_addstr(stdscr, footer_y, 2, " " * max(0, width - 4))
+    _safe_addstr(stdscr, footer_y, 2, footer_text[: max(0, width - 4)], palette["footer"])
+
+    _clear_input_line(ctx)
+    stdscr.refresh()
+    return True
+
+
+def _prompt_input(
+    ctx: MenuContext,
+    prompt: str,
+    *,
+    default: Optional[str] = None,
+    required: bool = False,
+) -> Optional[str]:
+    """Prompt for a string value and optionally enforce ``required`` input."""
+
+    stdscr = ctx.stdscr
+    height, width = stdscr.getmaxyx()
+    label = prompt
+    if default is not None and default != "":
+        label = f"{prompt} [{default}]"
+    max_label = max(10, width - 12)
+    if len(label) > max_label:
+        label = f"{label[: max_label - 3]}..."
+    message = f"{label}: "
+    input_y = max(0, height - 4)
+
+    while True:
+        _clear_input_line(ctx)
+        _safe_addstr(stdscr, input_y, 2, message[: max(0, width - 4)], ctx.palette["detail_heading"])
+        start_x = min(width - 3, 2 + len(message))
+        max_chars = max(1, width - start_x - 2)
+        curses.echo()
+        try:
+            curses.curs_set(1)
+        except curses.error:
+            pass
+        stdscr.move(input_y, start_x)
+        stdscr.refresh()
+        try:
+            raw = stdscr.getstr(input_y, start_x, max_chars)
+        except curses.error:
+            raw = b""
+        finally:
+            curses.noecho()
+            try:
+                curses.curs_set(0)
+            except curses.error:
+                pass
+        value = raw.decode("utf-8", errors="ignore").strip()
+        _clear_input_line(ctx)
+
+        if not value:
+            if default is not None:
+                return default
+            if not required:
+                return None
+            curses.flash()
+            _menu_log("prompt_missing", prompt=prompt, menu=ctx.current_menu)
+            continue
+        return value
+
+
+def _prompt_bool(ctx: MenuContext, prompt: str, *, default: bool = False) -> bool:
+    """Prompt the operator for a boolean decision."""
+
+    suffix = " [Y/n]" if default else " [y/N]"
+    default_token = "y" if default else "n"
+    while True:
+        response = _prompt_input(
+            ctx,
+            f"{prompt}{suffix}",
+            default=default_token,
+            required=False,
+        )
+        if response is None:
+            return default
+        value = response.strip().lower()
+        if value in {"y", "yes"}:
+            return True
+        if value in {"n", "no"}:
+            return False
+        curses.flash()
+        _menu_log("invalid_input", prompt=prompt, value=value, menu=ctx.current_menu, kind="bool")
+
+
+def _prompt_int(
+    ctx: MenuContext,
+    prompt: str,
+    *,
+    default: Optional[int] = None,
+    minimum: Optional[int] = None,
+) -> Optional[int]:
+    """Prompt for an integer value respecting ``minimum`` when provided."""
+
+    default_str = str(default) if default is not None else None
+    while True:
+        response = _prompt_input(
+            ctx,
+            prompt,
+            default=default_str,
+            required=default is None,
+        )
+        if response is None:
+            return default
+        try:
+            value = int(response)
+        except ValueError:
+            curses.flash()
+            _menu_log("invalid_input", prompt=prompt, value=response, menu=ctx.current_menu, kind="int")
+            continue
+        if minimum is not None and value < minimum:
+            curses.flash()
+            _menu_log(
+                "invalid_input",
+                prompt=prompt,
+                value=value,
+                menu=ctx.current_menu,
+                kind="int",
+                issue="lt_minimum",
+                minimum=minimum,
+            )
+            continue
+        return value
+
+
+def _prompt_choice(
+    ctx: MenuContext, prompt: str, choices: Sequence[str], *, default: Optional[str] = None
+) -> Optional[str]:
+    """Prompt for a value constrained to ``choices``."""
+
+    display = "/".join(choices)
+    base_prompt = f"{prompt} ({display})"
+    while True:
+        response = _prompt_input(
+            ctx,
+            base_prompt,
+            default=default,
+            required=default is None,
+        )
+        if response is None:
+            return default
+        value = response.strip().lower()
+        for choice in choices:
+            if value == choice.lower():
+                return choice.lower()
+        curses.flash()
+        _menu_log("invalid_input", prompt=prompt, value=response, menu=ctx.current_menu, kind="choice")
+
+
+def _invoke_command(
+    callback: Callable[[SimpleNamespace], object], **kwargs: object
+) -> Tuple[object, List[str]]:
+    """Invoke ``callback`` with ``kwargs`` capturing its stdout output."""
+
+    buffer = io.StringIO()
+    args = SimpleNamespace(**kwargs)
+    with redirect_stdout(buffer):
+        result = callback(args)
+    output = [line.rstrip() for line in buffer.getvalue().splitlines() if line.strip()]
+    return result, output
+
+
+def _open_submenu(ctx: MenuContext, title: str, builder: MenuBuilder) -> None:
+    """Construct submenu entries via ``builder`` and run the menu loop."""
+
+    items = list(builder(ctx))
+    if not items or items[-1][1] is not None:
+        items.append(("Back", None))
+    _run_menu(ctx, title, items)
+
+
+def _run_menu(ctx: MenuContext, title: str, items: Sequence[MenuEntry]) -> None:
+    """Execute a submenu interaction loop for ``items``."""
+
+    ctx.stack.append(title)
+    ctx.current_menu = " › ".join(ctx.stack)
+    _menu_log("enter", menu=ctx.current_menu)
+    selected = 0
+    status_lines: List[str] = []
+    exit_reason = "return"
+
+    try:
+        while True:
+            rendered = _render_submenu(ctx, title, items, selected, status_lines)
+            key = ctx.stdscr.getch()
+
+            if key in QUIT_KEYS:
+                exit_reason = "quit"
+                _menu_log("navigate", menu=ctx.current_menu, direction="quit")
+                break
+            if key == curses.KEY_RESIZE:
+                continue
+            if not rendered:
+                continue
+
+            if key in ENTER_KEYS:
+                label, callback = items[selected]
+                if callback is None:
+                    exit_reason = "back"
+                    _menu_log("navigate", menu=ctx.current_menu, selection=label, direction="back")
+                    break
+                _menu_log("select", menu=ctx.current_menu, selection=label)
+                try:
+                    result = callback(ctx)
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    status_lines = [f"Error: {exc}"]
+                    _menu_log("action_error", menu=ctx.current_menu, selection=label, error=str(exc))
+                else:
+                    if result is not None:
+                        if isinstance(result, str):
+                            status_lines = [result]
+                        else:
+                            status_lines = [str(line) for line in result if str(line).strip()]
+                        if not status_lines:
+                            status_lines = [f"{label} complete."]
+                    _menu_log("action_complete", menu=ctx.current_menu, selection=label)
+                continue
+
+            if key in {curses.KEY_DOWN, curses.KEY_RIGHT, ord("\t")}:
+                selected = (selected + 1) % len(items)
+            elif key in {curses.KEY_UP, curses.KEY_LEFT, getattr(curses, "KEY_BTAB", 353)}:
+                selected = (selected - 1) % len(items)
+            elif ord("1") <= key <= ord("9"):
+                index = key - ord("1")
+                if index < len(items):
+                    selected = index
+                else:
+                    curses.flash()
+                    _menu_log("invalid_key", menu=ctx.current_menu, key=_key_repr(key))
+            elif key == ord("0") and items:
+                selected = len(items) - 1
+            else:
+                curses.flash()
+                _menu_log("invalid_key", menu=ctx.current_menu, key=_key_repr(key))
+    finally:
+        path = ctx.current_menu
+        _menu_log("exit", menu=path, reason=exit_reason)
+        ctx.stack.pop()
+        ctx.current_menu = " › ".join(ctx.stack)
+
+
+def _action_safe_list(ctx: MenuContext) -> List[str]:
+    """Display queued proposals for a Safe."""
+
+    address = _prompt_input(ctx, "Safe address", default=DEFAULT_SAFE, required=False) or DEFAULT_SAFE
+    record, output = _invoke_command(safe_cmd.status, safe_address=address)
+    lines = list(output) if output else [f"Safe {address} status retrieved."]
+    safe_info = record.get("safe", {}) if isinstance(record, dict) else {}
+    proposals = safe_info.get("queued") or []
+    if proposals:
+        lines.append("Queued proposals:")
+        for proposal in proposals:
+            pid = proposal.get("id", "?")
+            dest = proposal.get("to", "0x")
+            value = proposal.get("value", "0")
+            status = proposal.get("status", "pending")
+            lines.append(f"  • #{pid} → {dest} {value} [{status}]")
+    else:
+        lines.append("No queued proposals.")
+    return lines
+
+
+def _action_safe_propose(ctx: MenuContext) -> List[str]:
+    """Draft a new Safe proposal."""
+
+    to_addr = _prompt_input(ctx, "Recipient address", required=True)
+    value = _prompt_input(ctx, "ETH value", required=True)
+    data = _prompt_input(ctx, "Calldata (optional)", default="0x", required=False) or "0x"
+    record, output = _invoke_command(
+        safe_cmd.propose,
+        to=to_addr,
+        value=value,
+        data=data,
+    )
+    lines = output or [f"Drafted proposal to {to_addr} for {value}."]
+    if isinstance(record, dict):
+        proposal = record.get("proposal", {})
+        if proposal:
+            lines.append(
+                "Proposal #{identifier} status={status}".format(
+                    identifier=proposal.get("id", "?"),
+                    status=proposal.get("status", "pending"),
+                )
+            )
+    return lines
+
+
+def _action_safe_sign(ctx: MenuContext) -> List[str]:
+    """Sign a Safe proposal by identifier."""
+
+    proposal_id = _prompt_input(ctx, "Proposal ID to sign", required=True)
+    record, output = _invoke_command(safe_cmd.sign, proposal_id=proposal_id)
+    lines = output or [f"Signed proposal {proposal_id}."]
+    if isinstance(record, dict):
+        proposal = record.get("proposal", {})
+        if proposal:
+            lines.append(f"Status → {proposal.get('status', 'unknown')}")
+    return lines
+
+
+def _action_safe_execute(ctx: MenuContext) -> List[str]:
+    """Execute a Safe proposal by identifier."""
+
+    proposal_id = _prompt_input(ctx, "Proposal ID to execute", required=True)
+    record, output = _invoke_command(safe_cmd.exec, proposal_id=proposal_id)
+    lines = output or [f"Executed proposal {proposal_id}."]
+    if isinstance(record, dict):
+        proposal = record.get("proposal", {})
+        if proposal:
+            lines.append(f"Status → {proposal.get('status', 'unknown')}")
+    return lines
+
+
+def _action_safe_status(ctx: MenuContext) -> List[str]:
+    """Summarise Safe owners, threshold, and queue."""
+
+    address = _prompt_input(ctx, "Safe address", default=DEFAULT_SAFE, required=False) or DEFAULT_SAFE
+    record, output = _invoke_command(safe_cmd.status, safe_address=address)
+    lines = output or [f"Status retrieved for {address}."]
+    safe_info = record.get("safe", {}) if isinstance(record, dict) else {}
+    owners = safe_info.get("owners") or []
+    threshold = safe_info.get("threshold")
+    queued = safe_info.get("queued") or []
+    lines.append(f"Owners ({len(owners)}): {', '.join(owners) if owners else 'none'}")
+    if threshold is not None:
+        lines.append(f"Threshold: {threshold}")
+    lines.append(f"Queued proposals: {len(queued)}")
+    return lines
+
+
+def _build_safe_proposals_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("List queued proposals", _action_safe_list),
+        ("Draft new proposal", _action_safe_propose),
+        ("Sign proposal", _action_safe_sign),
+        ("Execute proposal", _action_safe_execute),
+        ("Back", None),
+    ]
+
+
+def _enter_safe_proposals(ctx: MenuContext) -> Optional[Sequence[str]]:
+    _open_submenu(ctx, "Safe › Proposals", _build_safe_proposals_menu)
+    return None
+
+
+def _build_safe_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Proposal workflow", _enter_safe_proposals),
+        ("Safe status overview", _action_safe_status),
+        ("Back", None),
+    ]
+
+
+def _action_tx_simulate(ctx: MenuContext) -> List[str]:
+    proposal_id = _prompt_input(ctx, "Proposal ID (optional)", required=False)
+    plan_path = _prompt_input(ctx, "Plan JSON path (optional)", required=False)
+    include_trace = _prompt_bool(ctx, "Include execution trace?", default=False)
+    ml_enabled = _prompt_bool(ctx, "Enable ML scoring?", default=True)
+    record, output = _invoke_command(
+        tx_cmd.simulate,
+        proposal_id=proposal_id,
+        plan=plan_path,
+        trace=include_trace,
+        ml_off=not ml_enabled,
+    )
+    lines = output or ["Simulation executed."]
+    if isinstance(record, dict):
+        lines.append(f"Plan digest: {record.get('plan_digest')}")
+        lines.append(f"Gas used: {record.get('gas_used')}")
+        success = record.get("success")
+        if success is not None:
+            lines.append(f"Success: {success}")
+        trace_steps = record.get("trace") or []
+        if trace_steps:
+            lines.append("Trace steps:")
+            lines.extend(f"  • {step}" for step in trace_steps)
+    return lines
+
+
+def _action_tx_exec(ctx: MenuContext) -> List[str]:
+    proposal_id = _prompt_input(ctx, "Proposal ID to queue", required=True)
+    record, output = _invoke_command(tx_cmd.exec, proposal_id=proposal_id)
+    lines = output or [f"Execution payload queued for {proposal_id}."]
+    if isinstance(record, dict):
+        path = record.get("payload_path")
+        if path:
+            lines.append(f"Payload written to {path}")
+    return lines
+
+
+def _build_tx_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Simulate Safe/DeFi plan", _action_tx_simulate),
+        ("Queue execution payload", _action_tx_exec),
+        ("Back", None),
+    ]
+
+
+def _action_secrets_list(ctx: MenuContext) -> List[str]:
+    record, output = _invoke_command(secrets_cmd.list_secrets)
+    lines = list(output) if output else ["Retrieved secrets snapshot."]
+    if isinstance(record, dict):
+        entries = record.get("entries") or []
+        if entries:
+            for entry in entries:
+                sources = ", ".join(entry.get("sources", [])) or "no sources"
+                lines.append(f"{entry.get('key')}: {entry.get('status', 'unknown')} ({sources})")
+        else:
+            lines.append("No secrets tracked yet.")
+    return lines
+
+
+def _action_secrets_add(ctx: MenuContext) -> List[str]:
+    key = _prompt_input(ctx, "Secret key", required=True)
+    value = _prompt_input(ctx, "Secret value", required=True)
+    record, output = _invoke_command(secrets_cmd.add_secret, key=key, value=value)
+    lines = output or [f"Stored secret {key}."]
+    if isinstance(record, dict):
+        lines.append(f"Status: {record.get('status', 'stored')}")
+    return lines
+
+
+def _action_secrets_rotate(ctx: MenuContext) -> List[str]:
+    key = _prompt_input(ctx, "Secret key to rotate", required=True)
+    record, output = _invoke_command(secrets_cmd.rotate_secret, key=key)
+    lines = output or [f"Rotated secret {key}."]
+    if isinstance(record, dict):
+        preview = record.get("preview")
+        if preview:
+            lines.append(f"Preview: {preview}")
+    return lines
+
+
+def _action_secrets_remove(ctx: MenuContext) -> List[str]:
+    key = _prompt_input(ctx, "Secret key to remove", required=True)
+    record, output = _invoke_command(secrets_cmd.remove_secret, key=key)
+    lines = output or [f"Removal attempted for {key}."]
+    if isinstance(record, dict):
+        lines.append(f"Status: {record.get('status', 'removed')}")
+    return lines
+
+
+def _build_secrets_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("List tracked secrets", _action_secrets_list),
+        ("Add secret", _action_secrets_add),
+        ("Rotate secret", _action_secrets_rotate),
+        ("Remove secret", _action_secrets_remove),
+        ("Back", None),
+    ]
+
+
+def _action_sync_inspect(ctx: MenuContext) -> List[str]:
+    coordinator = aes.get_secrets_coordinator()
+    snapshot = coordinator.snapshot()
+    drift = coordinator.detect_drift(snapshot)
+    status = "in-sync" if not drift else "drift"
+    logbook.info({"action": "sync_inspect", "status": status, "drift": drift})
+    if not drift:
+        return ["All secret stores aligned across environments."]
+    lines = ["Drift detected across stores:"]
+    for key, stores in drift.items():
+        store_values = ", ".join(f"{name}={value}" for name, value in stores.items())
+        lines.append(f"  • {key}: {store_values}")
+    return lines
+
+
+def _action_sync_reconcile(ctx: MenuContext) -> List[str]:
+    record, output = _invoke_command(sync_cmd.run, force=False, reconcile=True)
+    lines = output or ["Priority reconciliation complete."]
+    if isinstance(record, dict):
+        operations = record.get("operations") or []
+        lines.append(f"Applied {len(operations)} updates across stores.")
+    return lines
+
+
+def _action_sync_force(ctx: MenuContext) -> List[str]:
+    record, output = _invoke_command(sync_cmd.run, force=True, reconcile=False)
+    lines = output or ["Force sync applied across all stores."]
+    if isinstance(record, dict):
+        result = record.get("result") or {}
+        lines.append(f"Stores harmonised: {len(result)}")
+    return lines
+
+
+def _build_sync_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Inspect drift", _action_sync_inspect),
+        ("Reconcile using priority order", _action_sync_reconcile),
+        ("Force sync now", _action_sync_force),
+        ("Back", None),
+    ]
+
+
+def _action_audit_snapshot(ctx: MenuContext) -> List[str]:
+    record, output = _invoke_command(audit_cmd.run)
+    lines = output or ["Audit snapshot generated."]
+    if isinstance(record, dict):
+        json_path = record.get("json_path")
+        pdf_path = record.get("pdf_path")
+        if json_path:
+            lines.append(f"JSON report: {json_path}")
+        if pdf_path:
+            lines.append(f"PDF report: {pdf_path}")
+    return lines
+
+
+def _build_audit_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Generate forensic snapshot", _action_audit_snapshot),
+        ("Back", None),
+    ]
+
+
+def _make_graph_action(fmt: str) -> MenuCallback:
+    def _action(ctx: MenuContext) -> List[str]:
+        output_path = _prompt_input(ctx, "Custom output path (optional)", required=False)
+        record, output = _invoke_command(graph_cmd.view, format=fmt, output=output_path)
+        lines = output or [f"Rendered {fmt} graph."]
+        if isinstance(record, dict):
+            path = record.get("path")
+            if path:
+                lines.append(f"Saved to {path}")
+            highlighted = record.get("highlighted") or record.get("highlighted_routes") or []
+            if highlighted:
+                lines.append(f"Highlighted routes: {len(highlighted)}")
+        return lines
+
+    return _action
+
+
+def _build_graph_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Render SVG", _make_graph_action("svg")),
+        ("Render HTML", _make_graph_action("html")),
+        ("Render PNG", _make_graph_action("png")),
+        ("Back", None),
+    ]
+
+
+def _make_autopilot_action(mode: str) -> MenuCallback:
+    def _action(ctx: MenuContext) -> List[str]:
+        plan_path = _prompt_input(ctx, "Plan JSON path (optional)", required=False)
+        flags = {"dry_run": False, "execute": False, "alerts_only": False}
+        if mode == "dry-run":
+            flags["dry_run"] = True
+        elif mode == "execute":
+            flags["execute"] = True
+        elif mode == "alerts":
+            flags["alerts_only"] = True
+        record, output = _invoke_command(
+            autopilot_cmd.run,
+            plan=plan_path,
+            dry_run=flags["dry_run"],
+            execute=flags["execute"],
+            alerts_only=flags["alerts_only"],
+        )
+        lines = output or [f"Autopilot completed in {mode} mode."]
+        if isinstance(record, dict):
+            lines.append(f"Mode: {record.get('mode')}")
+            steps = record.get("steps") or []
+            if steps:
+                lines.append(f"Steps executed: {len(steps)}")
+        return lines
+
+    return _action
+
+
+def _build_autopilot_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Queue autopilot workflow", _make_autopilot_action("queue")),
+        ("Dry-run autopilot", _make_autopilot_action("dry-run")),
+        ("Execute autopilot now", _make_autopilot_action("execute")),
+        ("Alerts-only run", _make_autopilot_action("alerts")),
+        ("Back", None),
+    ]
+
+
+def _action_rescue_safe(ctx: MenuContext) -> List[str]:
+    safe_address = _prompt_input(ctx, "Safe address", default=DEFAULT_SAFE, required=False) or DEFAULT_SAFE
+    record, output = _invoke_command(rescue_cmd.rescue_safe, safe_address=safe_address)
+    lines = output or [f"Recovery wizard started for {safe_address}."]
+    if isinstance(record, dict):
+        steps = record.get("steps") or []
+        if steps:
+            lines.append("Recovery steps:")
+            lines.extend(f"  • {step}" for step in steps)
+    return lines
+
+
+def _action_rescue_rotate(ctx: MenuContext) -> List[str]:
+    record, output = _invoke_command(rescue_cmd.rotate_all)
+    lines = output or ["Rotation complete."]
+    if isinstance(record, dict):
+        owners = record.get("owners") or []
+        if owners:
+            lines.append(f"New owners: {', '.join(owners)}")
+    return lines
+
+
+def _action_rescue_freeze(ctx: MenuContext) -> List[str]:
+    target_type = _prompt_choice(ctx, "Target type", ["wallet", "safe"], default="wallet")
+    target_id = _prompt_input(ctx, "Target identifier", required=True)
+    reason = _prompt_input(ctx, "Reason", default="incident response", required=False) or "incident response"
+    record, output = _invoke_command(
+        rescue_cmd.freeze,
+        target_type=target_type,
+        target_id=target_id,
+        reason=reason,
+    )
+    lines = output or [f"{target_type} {target_id} frozen."]
+    if isinstance(record, dict):
+        token = record.get("unfreeze_token")
+        if token:
+            lines.append(f"Unfreeze token: {token}")
+    return lines
+
+
+def _build_rescue_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Start Safe recovery", _action_rescue_safe),
+        ("Rotate all signers", _action_rescue_rotate),
+        ("Freeze wallet or Safe", _action_rescue_freeze),
+        ("Back", None),
+    ]
+
+
+def _action_plugin_list(ctx: MenuContext) -> List[str]:
+    record, output = _invoke_command(plugin_cmd.list_plugins)
+    lines = output or ["Plugin registry snapshot fetched."]
+    if isinstance(record, dict):
+        plugins = record.get("plugins") or []
+        if plugins:
+            for entry in plugins:
+                lines.append(f"{entry.get('name')}@{entry.get('version')} ({entry.get('schema', 'n/a')})")
+        else:
+            lines.append("No plugins installed.")
+    return lines
+
+
+def _action_plugin_add(ctx: MenuContext) -> List[str]:
+    name = _prompt_input(ctx, "Plugin name", required=True)
+    record, output = _invoke_command(plugin_cmd.add_plugin, name=name)
+    lines = output or [f"Registered plugin {name}."]
+    if isinstance(record, dict):
+        plugin = record.get("plugin") or {}
+        if plugin:
+            lines.append(f"Version: {plugin.get('version', 'v1.0')}")
+    return lines
+
+
+def _action_plugin_remove(ctx: MenuContext) -> List[str]:
+    name = _prompt_input(ctx, "Plugin name to remove", required=True)
+    record, output = _invoke_command(plugin_cmd.remove_plugin, name=name)
+    lines = output or [f"Removal attempted for {name}."]
+    if isinstance(record, dict):
+        plugin = record.get("plugin") or {}
+        removed = plugin.get("removed")
+        lines.append("Removed." if removed else "Plugin missing.")
+    return lines
+
+
+def _action_plugin_swap(ctx: MenuContext) -> List[str]:
+    name = _prompt_input(ctx, "Plugin name", required=True)
+    version = _prompt_input(ctx, "Target version", required=True)
+    record, output = _invoke_command(plugin_cmd.swap, name=name, version=version)
+    lines = output or [f"Swap attempted for {name}."]
+    if isinstance(record, dict):
+        status = record.get("status")
+        lines.append(f"Status: {status}")
+        plugin = record.get("plugin") or {}
+        previous = plugin.get("previous_version")
+        if previous:
+            lines.append(f"{name}: {previous} → {plugin.get('version')}")
+    return lines
+
+
+def _build_plugins_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("List plugins", _action_plugin_list),
+        ("Add plugin", _action_plugin_add),
+        ("Remove plugin", _action_plugin_remove),
+        ("Swap plugin version", _action_plugin_swap),
+        ("Back", None),
+    ]
+
+
+def _action_guard_run(ctx: MenuContext) -> List[str]:
+    cycles = _prompt_int(ctx, "Number of guard cycles", default=3, minimum=1) or 3
+    record, output = _invoke_command(guard_cmd.run, cycles=cycles)
+    lines = output or [f"Guardian executed for {cycles} cycle(s)."]
+    if isinstance(record, dict):
+        alerts = record.get("alerts") or []
+        if alerts:
+            lines.append(f"Alerts: {', '.join(alerts)}")
+        else:
+            lines.append("No alerts raised.")
+    return lines
+
+
+def _build_guard_menu(ctx: MenuContext) -> Sequence[MenuEntry]:
+    return [
+        ("Run monitoring cycles", _action_guard_run),
+        ("Back", None),
+    ]
+
+
+def _show_safe_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Safe", _build_safe_menu)
+
+
+def _show_tx_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Tx", _build_tx_menu)
+
+
+def _show_secrets_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Secrets", _build_secrets_menu)
+
+
+def _show_sync_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Sync", _build_sync_menu)
+
+
+def _show_audit_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Audit", _build_audit_menu)
+
+
+def _show_graph_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Graph", _build_graph_menu)
+
+
+def _show_autopilot_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Autopilot", _build_autopilot_menu)
+
+
+def _show_rescue_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Rescue", _build_rescue_menu)
+
+
+def _show_plugins_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Plugins", _build_plugins_menu)
+
+
+def _show_guard_menu(ctx: MenuContext) -> None:
+    _open_submenu(ctx, "Guard", _build_guard_menu)
+
+
+SUBMENU_DISPATCH: Dict[str, Callable[[MenuContext], None]] = {
+    "Safe": _show_safe_menu,
+    "Tx": _show_tx_menu,
+    "Secrets": _show_secrets_menu,
+    "Sync": _show_sync_menu,
+    "Audit": _show_audit_menu,
+    "Graph": _show_graph_menu,
+    "Autopilot": _show_autopilot_menu,
+    "Rescue": _show_rescue_menu,
+    "Plugins": _show_plugins_menu,
+    "Guard": _show_guard_menu,
+}
+
+
+def launch_tui() -> None:
+    """Launch the GNOMAN mission control curses interface."""
+
+    exit_request: Dict[str, str] = {"mode": "quit"}
+
+    def main(stdscr: "curses._CursesWindow") -> None:
+        try:
+            curses.curs_set(0)
+        except curses.error:
+            pass
+
+        stdscr.nodelay(False)
+        stdscr.keypad(True)
+
+        palette: Dict[str, int] = {
+            "title": curses.A_BOLD,
+            "subtitle": curses.A_DIM,
+            "menu_active": curses.A_REVERSE | curses.A_BOLD,
+            "menu_inactive": curses.A_NORMAL,
+            "menu_key": curses.A_BOLD,
+            "detail_heading": curses.A_BOLD,
+            "detail_text": curses.A_NORMAL,
+            "status": curses.A_BOLD,
+            "footer": curses.A_DIM,
+        }
+
+        if curses.has_colors():
+            curses.start_color()
+            curses.use_default_colors()
+            curses.init_pair(1, curses.COLOR_CYAN, -1)
+            curses.init_pair(2, curses.COLOR_MAGENTA, -1)
+            curses.init_pair(3, curses.COLOR_YELLOW, -1)
+            curses.init_pair(4, curses.COLOR_GREEN, -1)
+            palette["title"] = curses.color_pair(1) | curses.A_BOLD
+            palette["menu_active"] = curses.color_pair(1) | curses.A_REVERSE | curses.A_BOLD
+            palette["menu_key"] = curses.color_pair(2) | curses.A_BOLD
+            palette["detail_heading"] = curses.color_pair(3) | curses.A_BOLD
+            palette["status"] = curses.color_pair(4) | curses.A_BOLD
+            palette["footer"] = curses.color_pair(2) | curses.A_DIM
+
+        context = MenuContext(stdscr=stdscr, palette=palette)
+        exit_request["mode"] = "quit"
+
+        selected = 0
+        while True:
+            rendered = _render_dashboard(stdscr, selected, palette)
+            key = stdscr.getch()
+
+            if key in QUIT_KEYS:
+                exit_request["mode"] = "quit"
+                break
+            if key == curses.KEY_RESIZE:
+                continue
+            if not rendered:
+                # Ignore navigation until the terminal is big enough again.
+                continue
+
+            if key in KEY_TO_INDEX:
+                selected = KEY_TO_INDEX[key]
+                continue
+
+            if key in ENTER_KEYS:
+                item = MENU_ITEMS[selected]
+                if item.get("mode") == "legacy":
+                    exit_request["mode"] = "legacy"
+                    _menu_log("legacy_launch", menu=item.get("title"))
+                    break
+                handler = SUBMENU_DISPATCH.get(str(item.get("title")))
+                if handler is not None:
+                    context.stdscr = stdscr
+                    context.palette = palette
+                    context.stack.clear()
+                    context.current_menu = ""
+                    handler(context)
+                else:
+                    _menu_log("missing_submenu", menu=item.get("title"))
+                continue
+
+            if key in {curses.KEY_DOWN, curses.KEY_RIGHT, ord("\t")}:
+                selected = (selected + 1) % len(MENU_ITEMS)
+            elif key in {curses.KEY_UP, curses.KEY_LEFT, getattr(curses, "KEY_BTAB", 353)}:
+                selected = (selected - 1) % len(MENU_ITEMS)
+
+    while True:
+        curses.wrapper(main)
+        mode = exit_request.get("mode", "quit")
+        if mode == "legacy":
+            print("\nLaunching GNOMAN legacy console. Select 'Exit' to return to Mission Control.\n")
+            core.run_console(shutdown_logging=False)
+            print("\n⬅ Returning to Mission Control dashboard...\n")
+            continue
+        break

--- a/gnoman/utils/aes.py
+++ b/gnoman/utils/aes.py
@@ -1,0 +1,700 @@
+"""In-memory stand-ins for AES managers used by the GNOMAN CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+SECRETS_PRIORITY = ["keyring", "env", "env_secure", "hashicorp", "aws"]
+SECRETS_STORES: Dict[str, Dict[str, str]] = {
+    "keyring": {
+        "RPC_URL": "https://mainnet.infura.io/v3/demo",
+        "SAFE_OWNER": "0xOwnerA",
+        "DISCORD_WEBHOOK": "https://discord.example/webhook",
+    },
+    "env": {
+        "RPC_URL": "https://mainnet.infura.io/v3/demo",
+        "SAFE_OWNER": "0xOwnerB",
+        "DISCORD_WEBHOOK": "https://discord.example/webhook",
+    },
+    "env_secure": {
+        "RPC_URL": "https://mainnet.infura.io/v3/demo",
+        "SAFE_OWNER": "0xOwnerA",
+        "DISCORD_WEBHOOK": "https://discord.example/webhook",
+    },
+    "hashicorp": {
+        "RPC_URL": "https://mainnet.infura.io/v3/demo",
+        "SAFE_OWNER": "0xOwnerB",
+        "DISCORD_WEBHOOK": "https://discord.example/webhook",
+    },
+    "aws": {
+        "RPC_URL": "https://mainnet.infura.io/v3/demo",
+        "SAFE_OWNER": "0xOwnerA",
+        "DISCORD_WEBHOOK": "https://discord.example/webhook",
+    },
+}
+
+SECRETS_METADATA: Dict[str, Dict[str, Any]] = {
+    "RPC_URL": {"expires_at": time.time() + 60 * 60 * 24 * 30, "last_access": time.time() - 600},
+    "SAFE_OWNER": {"expires_at": time.time() + 60 * 60 * 24 * 2, "last_access": time.time() - 3600},
+    "DISCORD_WEBHOOK": {"expires_at": time.time() + 60 * 60 * 24 * 7, "last_access": time.time() - 120},
+}
+
+WALLET_INVENTORY: List[Dict[str, Any]] = [
+    {
+        "name": "Executor-1",
+        "address": "0xfeedfacecafebeef000000000000000000000001",
+        "balance": 12.3,
+        "last_access": time.time() - 1800,
+    },
+    {
+        "name": "Executor-2",
+        "address": "0xfeedfacecafebeef000000000000000000000002",
+        "balance": 4.8,
+        "last_access": time.time() - 4200,
+    },
+]
+
+SAFE_STATE: Dict[str, Dict[str, Any]] = {
+    "0xSAFECORE": {
+        "owners": ["0xOwnerA", "0xOwnerB", "0xOwnerC"],
+        "threshold": 2,
+        "proposals": [
+            {
+                "id": "1",
+                "to": "0xabc",
+                "value": "1 ETH",
+                "status": "pending",
+                "created_at": time.time() - 7200,
+            },
+            {
+                "id": "2",
+                "to": "0xdef",
+                "value": "0.5 ETH",
+                "status": "signed",
+                "created_at": time.time() - 3600,
+            },
+        ],
+    }
+}
+
+PLUGIN_REGISTRY: Dict[str, Dict[str, Any]] = {
+    "balancer_trade": {"version": "v5.0", "schema": "trade-execution"},
+    "ml-risk": {"version": "v1.3", "schema": "ml-score"},
+}
+
+PLUGIN_HISTORY: List[Dict[str, Any]] = []
+
+FROZEN_ENTITIES: Dict[Tuple[str, str], Dict[str, Any]] = {}
+ROTATION_STATE: Dict[str, Any] = {"last_rotation": None, "rotated_owners": []}
+
+GRAPH_ROUTES: List[Dict[str, Any]] = [
+    {
+        "path": ["DAI", "ETH", "USDC"],
+        "profit_bps": 24,
+        "status": "active",
+    },
+    {
+        "path": ["WBTC", "ETH", "ARB"],
+        "profit_bps": -3,
+        "status": "idle",
+    },
+]
+
+ALERT_CHANNELS = ["Discord", "Slack", "PagerDuty"]
+
+
+def _timestamp() -> int:
+    return int(time.time())
+
+
+class SecretsSyncCoordinator:
+    """Coordinate reconciliation between the various secret stores."""
+
+    def __init__(self, stores: Dict[str, Dict[str, str]], priority: Iterable[str]):
+        self._stores = stores
+        self._priority = list(priority)
+
+    def snapshot(self) -> Dict[str, Dict[str, str]]:
+        return {name: values.copy() for name, values in self._stores.items()}
+
+    def keys(self) -> List[str]:
+        keys: set[str] = set()
+        for values in self._stores.values():
+            keys.update(values.keys())
+        return sorted(keys)
+
+    def detect_drift(self, snapshot: Optional[Dict[str, Dict[str, str]]] = None) -> Dict[str, Dict[str, str]]:
+        snap = snapshot or self.snapshot()
+        drift: Dict[str, Dict[str, str]] = {}
+        for key in self.keys():
+            seen = {}
+            for store, values in snap.items():
+                if key in values:
+                    seen[store] = values[key]
+            if len(set(seen.values())) > 1:
+                drift[key] = seen
+        return drift
+
+    def authoritative_value(self, key: str) -> Tuple[Optional[str], Optional[str]]:
+        for store in self._priority:
+            values = self._stores.get(store, {})
+            if key in values:
+                return store, values[key]
+        return None, None
+
+    def reconcile_priority(self) -> List[Dict[str, Any]]:
+        actions: List[Dict[str, Any]] = []
+        for key in self.keys():
+            store, value = self.authoritative_value(key)
+            if store is None:
+                continue
+            for target in self._stores.values():
+                target[key] = value
+            actions.append({"key": key, "value": value, "source": store, "mode": "priority"})
+        return actions
+
+    def apply_decisions(self, decisions: Dict[str, Tuple[str, str]]) -> List[Dict[str, Any]]:
+        actions: List[Dict[str, Any]] = []
+        for key, (store, value) in decisions.items():
+            for target in self._stores.values():
+                target[key] = value
+            actions.append({"key": key, "value": value, "source": store, "mode": "manual"})
+        return actions
+
+    def force_sync(self) -> List[Dict[str, Any]]:
+        return self.reconcile_priority()
+
+    def set_secret(self, key: str, value: str) -> None:
+        for store in self._stores.values():
+            store[key] = value
+        SECRETS_METADATA[key] = {
+            "expires_at": time.time() + 60 * 60 * 24 * 30,
+            "last_access": time.time(),
+        }
+
+    def rotate_secret(self, key: str) -> str:
+        new_value = hashlib.sha256(f"{key}-{time.time()}".encode("utf-8")).hexdigest()[:16]
+        self.set_secret(key, new_value)
+        return new_value
+
+    def remove_secret(self, key: str) -> None:
+        for store in self._stores.values():
+            store.pop(key, None)
+        SECRETS_METADATA.pop(key, None)
+
+    def metadata(self, key: str) -> Dict[str, Any]:
+        return SECRETS_METADATA.get(key, {})
+
+
+class AuditCollector:
+    """Aggregate wallet, Safe, and secret metadata for forensic reports."""
+
+    def collect(self) -> Dict[str, Any]:
+        now = _timestamp()
+        expiring: List[Dict[str, Any]] = []
+        for key, meta in SECRETS_METADATA.items():
+            expires_at = int(meta.get("expires_at", 0))
+            if expires_at and expires_at - now < 60 * 60 * 24 * 7:
+                expiring.append(
+                    {
+                        "key": key,
+                        "expires_at": expires_at,
+                        "expires_in_days": round((expires_at - now) / (60 * 60 * 24), 2),
+                    }
+                )
+        safes = []
+        for address, data in SAFE_STATE.items():
+            safes.append(
+                {
+                    "address": address,
+                    "owners": data["owners"],
+                    "threshold": data["threshold"],
+                    "queued": [
+                        {
+                            "id": proposal["id"],
+                            "to": proposal["to"],
+                            "value": proposal["value"],
+                            "status": proposal["status"],
+                        }
+                        for proposal in data.get("proposals", [])
+                    ],
+                }
+            )
+        return {
+            "generated_at": now,
+            "wallets": WALLET_INVENTORY,
+            "safes": safes,
+            "expiring_secrets": expiring,
+        }
+
+
+class AuditSigner:
+    """Derive a deterministic signature using the GNOMAN audit key."""
+
+    def __init__(self, key: str = "GNOMAN-AUDIT-KEY") -> None:
+        self._key = key.encode("utf-8")
+
+    def sign(self, payload: Dict[str, Any]) -> str:
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(self._key + body).hexdigest()
+
+
+class SimulationEngine:
+    """Simulate transactions against a local fork."""
+
+    def simulate(
+        self,
+        proposal_id: Optional[str],
+        plan_path: Optional[str],
+        trace: bool,
+        ml_enabled: bool,
+    ) -> Dict[str, Any]:
+        plan_digest = ""
+        plan_payload: Optional[Dict[str, Any]] = None
+        if plan_path:
+            path = Path(plan_path)
+            if path.exists():
+                try:
+                    plan_payload = json.loads(path.read_text())
+                except json.JSONDecodeError:
+                    plan_payload = {"raw": path.read_text()}
+        seed_source = plan_path or proposal_id or str(time.time())
+        seed = int(hashlib.sha256(seed_source.encode("utf-8")).hexdigest(), 16)
+        random.seed(seed)
+        gas_used = random.randint(21000, 350000)
+        success = random.random() > 0.1
+        revert_reason = None if success else random.choice([
+            "SAFE_THRESHOLD_NOT_MET",
+            "ERC20: transfer amount exceeds balance",
+            "AAVE: insufficient collateral",
+        ])
+        ml_score = None if not ml_enabled else round(random.uniform(0.6, 0.99), 3)
+        plan_digest = hashlib.sha1(seed_source.encode("utf-8")).hexdigest()[:10]
+        trace_steps: List[str] = []
+        if trace:
+            trace_steps = [
+                "start_fork(anvil)",
+                "deploy_safe_proxy()",
+                f"execute_plan({plan_digest})",
+                "collect_gas_metrics()",
+            ]
+        return {
+            "proposal_id": proposal_id,
+            "plan_path": plan_path,
+            "plan_payload": plan_payload,
+            "plan_digest": plan_digest,
+            "success": success,
+            "gas_used": gas_used,
+            "revert_reason": revert_reason,
+            "ml_score": ml_score,
+            "trace": trace_steps,
+        }
+
+
+class RecoveryManager:
+    """Provide incident response helpers."""
+
+    def start_safe_recovery(self, safe_address: str) -> Dict[str, Any]:
+        safe = SAFE_STATE.get(safe_address, SAFE_STATE["0xSAFECORE"])
+        steps = [
+            "verify_owner_chain",
+            "generate_replacement_signers",
+            "stage_new_threshold_payload",
+            "broadcast_emergency_rotation",
+        ]
+        return {
+            "safe": safe_address,
+            "current_threshold": safe["threshold"],
+            "owners": safe["owners"],
+            "steps": steps,
+            "status": "wizard_started",
+            "started_at": _timestamp(),
+        }
+
+    def rotate_all(self) -> Dict[str, Any]:
+        new_owners = [f"0xROTATED{i:02d}" for i in range(1, 4)]
+        SAFE_STATE["0xSAFECORE"]["owners"] = new_owners
+        ROTATION_STATE["last_rotation"] = _timestamp()
+        ROTATION_STATE["rotated_owners"] = new_owners
+        return {
+            "timestamp": ROTATION_STATE["last_rotation"],
+            "owners": new_owners,
+            "status": "rotated",
+        }
+
+    def freeze(self, target_type: str, target_id: str, reason: str) -> Dict[str, Any]:
+        key = (target_type, target_id)
+        entry = {
+            "reason": reason,
+            "frozen_at": _timestamp(),
+            "unfreeze_token": hashlib.sha256(f"{target_type}:{target_id}:{time.time()}".encode()).hexdigest()[:12],
+        }
+        FROZEN_ENTITIES[key] = entry
+        return {"target_type": target_type, "target_id": target_id, **entry}
+
+
+class GraphManager:
+    """Render AES graph insights."""
+
+    def render(self, fmt: str, output_path: Optional[str]) -> Dict[str, Any]:
+        timestamp = _timestamp()
+        root = Path.home() / ".gnoman" / "graphs"
+        root.mkdir(parents=True, exist_ok=True)
+        if output_path:
+            path = Path(output_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            path = root / f"graph-{timestamp}.{fmt}"
+        highlight = [route for route in GRAPH_ROUTES if route["status"] == "active"]
+        if fmt == "svg":
+            neon_svg = self._render_svg(highlight)
+            path.write_text(neon_svg, encoding="utf-8")
+        elif fmt == "html":
+            svg = self._render_svg(highlight)
+            html = f"<html><body><h1>GNOMAN Graph</h1>{svg}</body></html>"
+            path.write_text(html, encoding="utf-8")
+        else:
+            path.write_bytes(self._neon_png())
+        return {
+            "path": str(path),
+            "format": fmt,
+            "highlighted_routes": highlight,
+            "generated_at": timestamp,
+        }
+
+    @staticmethod
+    def _render_svg(routes: List[Dict[str, Any]]) -> str:
+        lines = []
+        for idx, route in enumerate(routes):
+            y = 40 + idx * 40
+            label = " → ".join(route["path"])
+            lines.append(
+                f'<text x="20" y="{y}" fill="#39FF14" font-family="monospace" font-size="18">{label} (bps {route["profit_bps"]})</text>'
+            )
+        content = "".join(lines) or "<text x=\"20\" y=\"40\" fill=\"#39FF14\">No active routes</text>"
+        return f"<svg xmlns='http://www.w3.org/2000/svg' width='640' height='200' style='background:#050505'>{content}</svg>"
+
+    @staticmethod
+    def _neon_png() -> bytes:
+        # 1x1 PNG with neon green pixel.
+        return bytes(
+            [
+                0x89,
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+                0x00,
+                0x00,
+                0x00,
+                0x0D,
+                0x49,
+                0x48,
+                0x44,
+                0x52,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                0x08,
+                0x02,
+                0x00,
+                0x00,
+                0x00,
+                0x90,
+                0x77,
+                0x53,
+                0xDE,
+                0x00,
+                0x00,
+                0x00,
+                0x0A,
+                0x49,
+                0x44,
+                0x41,
+                0x54,
+                0x08,
+                0xD7,
+                0x63,
+                0xF8,
+                0xCF,
+                0xC0,
+                0x00,
+                0x00,
+                0x03,
+                0x00,
+                0x01,
+                0xE2,
+                0x21,
+                0xBC,
+                0x33,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x49,
+                0x45,
+                0x4E,
+                0x44,
+                0xAE,
+                0x42,
+                0x60,
+                0x82,
+            ]
+        )
+
+
+class PluginRegistry:
+    """Manage AES plugin metadata and enforce schema validation."""
+
+    def list(self) -> List[Dict[str, Any]]:
+        return [
+            {"name": name, **info}
+            for name, info in sorted(PLUGIN_REGISTRY.items())
+        ]
+
+    def add(self, name: str) -> Dict[str, Any]:
+        entry = PLUGIN_REGISTRY.setdefault(name, {"version": "v1.0", "schema": "custom"})
+        record = {"name": name, **entry, "status": "registered"}
+        return record
+
+    def remove(self, name: str) -> Dict[str, Any]:
+        entry = PLUGIN_REGISTRY.pop(name, None)
+        return {"name": name, "removed": entry is not None, "status": "removed"}
+
+    def swap(self, name: str, version: str) -> Dict[str, Any]:
+        if name not in PLUGIN_REGISTRY:
+            raise ValueError(f"Unknown plugin: {name}")
+        previous = PLUGIN_REGISTRY[name]["version"]
+        schema = PLUGIN_REGISTRY[name]["schema"]
+        if not schema:
+            raise ValueError("Plugin schema missing; cannot validate swap")
+        PLUGIN_REGISTRY[name]["version"] = version
+        record = {
+            "name": name,
+            "previous_version": previous,
+            "version": version,
+            "schema": schema,
+            "validated": True,
+            "timestamp": _timestamp(),
+        }
+        PLUGIN_HISTORY.append(record)
+        return record
+
+    def snapshot_versions(self) -> Dict[str, str]:
+        return {name: info["version"] for name, info in PLUGIN_REGISTRY.items()}
+
+    def record_usage(self, plugin: str, version: str, context: str) -> None:
+        PLUGIN_HISTORY.append(
+            {
+                "name": plugin,
+                "version": version,
+                "context": context,
+                "timestamp": _timestamp(),
+            }
+        )
+
+
+class Guardian:
+    """Run monitoring cycles and emit alerts when thresholds drift."""
+
+    def run(self, cycles: int) -> Dict[str, Any]:
+        reports: List[Dict[str, Any]] = []
+        alerts: List[str] = []
+        for _ in range(max(1, cycles)):
+            secrets_ok = not SecretsSyncCoordinator(SECRETS_STORES, SECRETS_PRIORITY).detect_drift()
+            quorum_ok = SAFE_STATE["0xSAFECORE"]["threshold"] <= len(SAFE_STATE["0xSAFECORE"]["owners"])
+            low_balances = [w for w in WALLET_INVENTORY if w["balance"] < 1]
+            gas_price = random.randint(18, 64)
+            profitable_routes = [r for r in GRAPH_ROUTES if r["profit_bps"] > 10]
+            cycle = {
+                "timestamp": _timestamp(),
+                "secrets_ok": secrets_ok,
+                "safe_quorum_ok": quorum_ok,
+                "low_balances": [w["address"] for w in low_balances],
+                "gas_gwei": gas_price,
+                "profitable_routes": profitable_routes,
+            }
+            if not secrets_ok:
+                alerts.append("Secret drift detected")
+            if low_balances:
+                alerts.append("Wallet balance below threshold")
+            if profitable_routes:
+                alerts.append("Arbitrage opportunity detected")
+            reports.append(cycle)
+        alert_targets = ALERT_CHANNELS if alerts else []
+        return {
+            "cycles": reports,
+            "alerts": alerts,
+            "alert_channels": alert_targets,
+        }
+
+
+class SafeRegistry:
+    """Track Safe proposals and state for CLI commands."""
+
+    def __init__(self, state: Dict[str, Dict[str, Any]]):
+        self._state = state
+        self._counter = max(
+            (int(p["id"]) for safe in state.values() for p in safe.get("proposals", [])),
+            default=0,
+        )
+
+    def propose(self, to: str, value: str, data: str) -> Dict[str, Any]:
+        self._counter += 1
+        proposal = {
+            "id": str(self._counter),
+            "to": to,
+            "value": value,
+            "data": data,
+            "status": "pending",
+            "created_at": _timestamp(),
+        }
+        SAFE_STATE["0xSAFECORE"].setdefault("proposals", []).append(proposal)
+        return proposal
+
+    def sign(self, proposal_id: str) -> Dict[str, Any]:
+        proposal = self._find(proposal_id)
+        if proposal:
+            proposal["status"] = "signed"
+        return proposal or {"id": proposal_id, "status": "unknown"}
+
+    def execute(self, proposal_id: str) -> Dict[str, Any]:
+        proposal = self._find(proposal_id)
+        if proposal:
+            proposal["status"] = "executed"
+        return proposal or {"id": proposal_id, "status": "unknown"}
+
+    def status(self, safe_address: str) -> Dict[str, Any]:
+        safe = SAFE_STATE.get(safe_address)
+        if not safe:
+            return {"address": safe_address, "status": "unknown"}
+        return {
+            "address": safe_address,
+            "owners": safe["owners"],
+            "threshold": safe["threshold"],
+            "queued": safe.get("proposals", []),
+        }
+
+    def _find(self, proposal_id: str) -> Optional[Dict[str, Any]]:
+        for proposal in SAFE_STATE["0xSAFECORE"].get("proposals", []):
+            if proposal["id"] == proposal_id:
+                return proposal
+        return None
+
+
+class AutopilotOrchestrator:
+    """Run the AES trade automation pipeline."""
+
+    def __init__(self, plugin_registry: PluginRegistry, simulator: SimulationEngine) -> None:
+        self._plugins = plugin_registry
+        self._simulator = simulator
+
+    def execute(
+        self,
+        plan_path: Optional[str],
+        dry_run: bool,
+        execute: bool,
+        alerts_only: bool,
+    ) -> Dict[str, Any]:
+        plan_payload: Optional[Dict[str, Any]] = None
+        if plan_path and Path(plan_path).exists():
+            try:
+                plan_payload = json.loads(Path(plan_path).read_text())
+            except json.JSONDecodeError:
+                plan_payload = {"raw": Path(plan_path).read_text()}
+        steps: List[Dict[str, Any]] = []
+        steps.append({"name": "fetch_loans", "status": "ok", "count": 3})
+        steps.append({"name": "build_trades", "status": "ok", "paths": len(GRAPH_ROUTES)})
+        ml_score = round(random.uniform(0.75, 0.98), 3)
+        steps.append({"name": "ml_validate", "status": "ok", "score": ml_score})
+        simulation = self._simulator.simulate(
+            proposal_id="autopilot", plan_path=plan_path, trace=False, ml_enabled=True
+        )
+        steps.append({"name": "prepare_safe_payload", "status": "ok", "proposal": simulation["plan_digest"]})
+        steps.append({"name": "simulate", "status": "ok", "gas_used": simulation["gas_used"]})
+        mode = "alerts"
+        if execute:
+            mode = "execute"
+        elif dry_run:
+            mode = "dry-run"
+        elif alerts_only:
+            mode = "alerts"
+        else:
+            mode = "queue"
+        steps.append({"name": "dispatch", "status": "ok", "mode": mode})
+        plugin_versions = self._plugins.snapshot_versions()
+        for name, version in plugin_versions.items():
+            self._plugins.record_usage(name, version, context="autopilot")
+        return {
+            "mode": mode,
+            "steps": steps,
+            "plan_path": plan_path,
+            "plan_payload": plan_payload,
+            "plugin_versions": plugin_versions,
+        }
+
+
+_SECRETS_COORDINATOR = SecretsSyncCoordinator(SECRETS_STORES, SECRETS_PRIORITY)
+_AUDIT_COLLECTOR = AuditCollector()
+_AUDIT_SIGNER = AuditSigner()
+_SIMULATION_ENGINE = SimulationEngine()
+_RECOVERY_MANAGER = RecoveryManager()
+_GRAPH_MANAGER = GraphManager()
+_PLUGIN_REGISTRY = PluginRegistry()
+_GUARDIAN = Guardian()
+_SAFE_REGISTRY = SafeRegistry(SAFE_STATE)
+_AUTOPILOT = AutopilotOrchestrator(_PLUGIN_REGISTRY, _SIMULATION_ENGINE)
+
+
+def get_secrets_coordinator() -> SecretsSyncCoordinator:
+    return _SECRETS_COORDINATOR
+
+
+def get_audit_collector() -> AuditCollector:
+    return _AUDIT_COLLECTOR
+
+
+def get_audit_signer() -> AuditSigner:
+    return _AUDIT_SIGNER
+
+
+def get_simulation_engine() -> SimulationEngine:
+    return _SIMULATION_ENGINE
+
+
+def get_recovery_manager() -> RecoveryManager:
+    return _RECOVERY_MANAGER
+
+
+def get_graph_manager() -> GraphManager:
+    return _GRAPH_MANAGER
+
+
+def get_plugin_registry() -> PluginRegistry:
+    return _PLUGIN_REGISTRY
+
+
+def get_guardian() -> Guardian:
+    return _GUARDIAN
+
+
+def get_safe_registry() -> SafeRegistry:
+    return _SAFE_REGISTRY
+
+
+def get_autopilot() -> AutopilotOrchestrator:
+    return _AUTOPILOT

--- a/gnoman/utils/logbook.py
+++ b/gnoman/utils/logbook.py
@@ -1,0 +1,35 @@
+"""Rotating forensic logger emitting JSON lines."""
+
+from __future__ import annotations
+
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Dict
+
+LOG_ROOT = Path.home() / ".gnoman"
+LOG_DIR = LOG_ROOT / "logs"
+LOG_FILE = LOG_DIR / "gnoman.log"
+
+
+def _get_logger() -> logging.Logger:
+    logger = logging.getLogger("gnoman")
+    if logger.handlers:
+        return logger
+
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    handler = RotatingFileHandler(LOG_FILE, maxBytes=1_000_000, backupCount=5)
+    formatter = logging.Formatter("%(message)s")
+
+    logger.setLevel(logging.INFO)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+
+def info(record: Dict[str, object]) -> None:
+    """Write a forensic JSON record to the rotating log."""
+
+    logger = _get_logger()
+    logger.info(json.dumps(record))


### PR DESCRIPTION
## Summary
- restore the argparse-based command surface and mission control dashboard as the default CLI entrypoint
- add a Legacy console path in the dashboard and CLI that reuses a shared `core.run_console` helper
- bring back the command handlers and utility scaffolding that power the Safe, wallet, audit, and automation modules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfb2cb06c0832cad6289d8ef3841c9