### PR TITLE
Add file-based keyring fallback for iOS support

### DIFF
--- a/gnoman/core.py
+++ b/gnoman/core.py
@@ -46,6 +46,7 @@ from eth_account.signers.local import LocalAccount  # L039
 try:  # pragma: no branch - import resolution is environment-dependent.
     from .utils.abi import load_safe_abi
     from .utils import keyring_index
+    from .utils.keyring_compat import load_keyring_backend
 except ImportError:
     _pkg_root = Path(__file__).resolve().parent
     _project_root = _pkg_root.parent
@@ -56,9 +57,11 @@ except ImportError:
     try:
         from gnoman.utils.abi import load_safe_abi
         from gnoman.utils import keyring_index
+        from gnoman.utils.keyring_compat import load_keyring_backend
     except ImportError:
         from utils.abi import load_safe_abi  # type: ignore[import]
         import keyring_index  # type: ignore[import]
+        from keyring_compat import load_keyring_backend  # type: ignore[import]
 
 Account.enable_unaudited_hdwallet_features()  # L040
 
@@ -70,11 +73,8 @@ ERC20_ABI_MIN = [
     {"constant": True, "inputs": [], "name": "decimals","outputs":[{"name":"","type":"uint8"}], "type":"function"},
 ]  # L047
 
-# Optional keyring  # L048
-try:
-    import keyring  # L049
-except ImportError:
-    keyring = None  # L051
+# Optional keyring (with fallback for environments without a native backend)
+keyring = load_keyring_backend()
 
 
 # ───────── Logger (line-numbered) ─────────  # L052

--- a/gnoman/utils/keyring_compat.py
+++ b/gnoman/utils/keyring_compat.py
@@ -1,0 +1,191 @@
+"""Helpers for dealing with keyring availability across platforms.
+
+This module tries to provide a best-effort keyring backend so that GNOMAN
+continues to function on environments where the ``keyring`` package either is
+not available or ships without a functional backend (e.g. iOS builds of
+CPython).  The real keyring backend is preferred when present, otherwise a
+small JSON-file based implementation is used as a fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Dict, Optional
+
+from .keyring_index import KeyringLike
+
+logger = logging.getLogger(__name__)
+
+
+def _default_storage_path() -> Path:
+    """Return the path used by :class:`FileKeyring` when none is provided."""
+
+    override = os.getenv("GNOMAN_KEYRING_PATH")
+    if override:
+        try:
+            return Path(override).expanduser()
+        except Exception:  # pragma: no cover - extremely defensive
+            logger.debug("Invalid GNOMAN_KEYRING_PATH=%s", override, exc_info=True)
+    return Path.home() / ".gnoman" / "keyring.json"
+
+
+class FileKeyring:
+    """Very small JSON backed keyring implementation.
+
+    The implementation is intentionally tiny – it only supports the subset of
+    functionality that GNOMAN requires (``get_password``, ``set_password`` and
+    ``delete_password``).  All entries are namespaced by service and persisted
+    to a single JSON file.  Access is guarded by a process-level lock so that
+    concurrent callers do not trample over the file.
+    """
+
+    def __init__(self, storage_path: Optional[Path | str] = None) -> None:
+        if storage_path is None:
+            storage = _default_storage_path()
+        else:
+            storage = Path(storage_path)
+        self.storage_path = storage.expanduser()
+        self._lock = threading.Lock()
+
+    # -- internal utilities -------------------------------------------------
+    def _read_all(self) -> Dict[str, Dict[str, str]]:
+        if not self.storage_path.exists():
+            return {}
+        try:
+            payload = json.loads(self.storage_path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.debug("Failed to read keyring file; assuming empty", exc_info=True)
+            return {}
+        result: Dict[str, Dict[str, str]] = {}
+        if not isinstance(payload, dict):
+            return result
+        for service, entries in payload.items():
+            if not isinstance(service, str) or not isinstance(entries, dict):
+                continue
+            normalised: Dict[str, str] = {}
+            for key, value in entries.items():
+                if isinstance(key, str) and isinstance(value, str):
+                    normalised[key] = value
+            if normalised:
+                result[service] = normalised
+        return result
+
+    def _write_all(self, data: Dict[str, Dict[str, str]]) -> None:
+        if not data:
+            try:
+                self.storage_path.unlink()
+            except FileNotFoundError:
+                return
+            except Exception:  # pragma: no cover - failure to clean up is fine
+                logger.debug("Failed to remove empty keyring file", exc_info=True)
+                return
+            return
+
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.storage_path.with_suffix(self.storage_path.suffix + ".tmp")
+        try:
+            tmp_path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp_path, self.storage_path)
+        except Exception as exc:
+            logger.error("Failed to persist fallback keyring", exc_info=True)
+            raise RuntimeError("failed to persist keyring data") from exc
+        finally:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except Exception:  # pragma: no cover - best effort cleanup
+                logger.debug("Failed to clean up temporary keyring file", exc_info=True)
+
+    # -- public API ---------------------------------------------------------
+    def get_password(self, service: str, key: str) -> Optional[str]:
+        if not service or not key:
+            return None
+        with self._lock:
+            data = self._read_all()
+            return data.get(service, {}).get(key)
+
+    def set_password(self, service: str, key: str, value: str) -> None:
+        if not service or not key:
+            raise ValueError("service and key must be non-empty strings")
+        value = str(value)
+        with self._lock:
+            data = self._read_all()
+            bucket = data.setdefault(service, {})
+            bucket[key] = value
+            self._write_all(data)
+
+    def delete_password(self, service: str, key: str) -> None:
+        if not service or not key:
+            return
+        with self._lock:
+            data = self._read_all()
+            bucket = data.get(service)
+            if bucket and key in bucket:
+                bucket.pop(key, None)
+                if bucket:
+                    data[service] = bucket
+                else:
+                    data.pop(service, None)
+                self._write_all(data)
+
+
+def _try_native_keyring() -> Optional[KeyringLike]:
+    """Return the real keyring backend when usable, otherwise ``None``."""
+
+    try:  # pragma: no branch - import depends on environment
+        import keyring as native_keyring  # type: ignore
+    except Exception:
+        return None
+
+    backend = None
+    try:
+        backend = native_keyring.get_keyring()
+    except Exception:
+        return None
+
+    module_name = backend.__class__.__module__
+    if module_name.startswith("keyring.backends.fail"):
+        return None
+
+    priority = getattr(backend, "priority", None)
+    if isinstance(priority, (int, float)) and priority <= 0:
+        return None
+
+    try:
+        native_keyring.get_password("__gnoman_probe__", "__gnoman_probe__")
+    except Exception:
+        return None
+
+    return native_keyring  # type: ignore[return-value]
+
+
+def load_keyring_backend(storage_path: Optional[Path | str] = None) -> Optional[KeyringLike]:
+    """Return a keyring backend, preferring the system one when available.
+
+    When the native keyring is unavailable (which is the case on several iOS
+    Python distributions) a :class:`FileKeyring` instance is returned instead.
+    The caller receives ``None`` only if both mechanisms fail which mirrors the
+    previous behaviour of the application.
+    """
+
+    backend = _try_native_keyring()
+    if backend is not None:
+        logger.debug("Using native keyring backend: %s", backend)
+        return backend
+
+    try:
+        fallback = FileKeyring(storage_path=storage_path)
+    except Exception:
+        logger.error("Unable to initialise fallback keyring", exc_info=True)
+        return None
+
+    logger.info("Using file-based fallback keyring located at %s", fallback.storage_path)
+    return fallback
+
+
+__all__ = ["FileKeyring", "load_keyring_backend"]
+

--- a/gnoman/wallet/seed.py
+++ b/gnoman/wallet/seed.py
@@ -5,13 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-try:  # pragma: no cover - depends on runtime environment
-    import keyring  # type: ignore
-except Exception:  # pragma: no cover - if keyring is unavailable
-    keyring = None  # type: ignore
-
 from ..utils import keyring_index
 from ..utils.keyring_index import KeyringLike
+from ..utils.keyring_compat import load_keyring_backend
 
 
 class WalletSeedError(RuntimeError):
@@ -40,9 +36,10 @@ class WalletSeedManager:
 
     def __post_init__(self) -> None:
         if self.backend is None:
-            if keyring is None:
+            backend = load_keyring_backend()
+            if backend is None:
                 raise WalletSeedError("keyring backend is not available")
-            self.backend = keyring  # type: ignore[assignment]
+            self.backend = backend
 
     # -- internal helpers -------------------------------------------------
     def _get(self, key: str) -> Optional[str]:

--- a/tests/test_keyring_compat.py
+++ b/tests/test_keyring_compat.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gnoman.utils import keyring_compat
+
+
+def test_file_keyring_roundtrip(tmp_path: Path) -> None:
+    storage = tmp_path / "store.json"
+    backend = keyring_compat.FileKeyring(storage_path=storage)
+
+    assert backend.get_password("service", "alpha") is None
+
+    backend.set_password("service", "alpha", "secret")
+    assert backend.get_password("service", "alpha") == "secret"
+
+    # Ensure persistence across instances
+    another = keyring_compat.FileKeyring(storage_path=storage)
+    assert another.get_password("service", "alpha") == "secret"
+
+    another.delete_password("service", "alpha")
+    assert another.get_password("service", "alpha") is None
+
+    # No entries remain, so a new instance should see nothing either
+    fresh = keyring_compat.FileKeyring(storage_path=storage)
+    assert fresh.get_password("service", "alpha") is None
+
+
+def test_load_keyring_backend_falls_back(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(keyring_compat, "_try_native_keyring", lambda: None)
+
+    backend = keyring_compat.load_keyring_backend(storage_path=tmp_path / "fallback.json")
+    assert backend is not None
+
+    backend.set_password("svc", "key", "value")
+    assert backend.get_password("svc", "key") == "value"
+    backend.delete_password("svc", "key")
+    assert backend.get_password("svc", "key") is None


### PR DESCRIPTION
## Summary
- add a JSON-backed file keyring fallback to cover environments without a native keyring (such as iOS)
- update wallet seed handling and the legacy core script to use the compatibility loader
- add tests exercising the fallback implementation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0173c30b0832cb5013dbf67c22be7