### PR TITLE
Defer gnoman.core import in TUI to remove startup prompts

### DIFF
--- a/tests/test_tui_menu.py
+++ b/tests/test_tui_menu.py
@@ -73,6 +73,10 @@ def _palette() -> dict[str, int]:
     }
 
 
+def test_core_not_loaded_on_import() -> None:
+    assert tui._CORE_MODULE is None
+
+
 def test_root_menu_path_is_clean() -> None:
     window = FakeWindow(inputs=[ord("q")])
     ctx = tui.MenuContext(stdscr=window, palette=_palette())


### PR DESCRIPTION
## Summary
- lazily import `gnoman.core` inside the TUI and cache the module to avoid keyring prompts before curses renders
- update legacy Safe, wallet, and key manager helpers to pull from the cached module returned by `_ensure_safe_initialised`
- add a regression test confirming the core module remains unloaded when importing the TUI package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0507ad7d4832c924806d0203aae2a