### PR TITLE
Improve TUI menu robustness

### DIFF
--- a/gnoman/tui.py
+++ b/gnoman/tui.py
@@ -6,7 +6,7 @@ import curses
 import io
 from contextlib import contextmanager, redirect_stdout
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from textwrap import wrap
 from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
@@ -279,7 +279,7 @@ def _serialize(value: object) -> object:
 def _menu_log(action: str, **fields: object) -> None:
     """Emit a forensic menu log entry with ``action`` and ``fields``."""
 
-    timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    timestamp = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
     payload = {key: _serialize(value) for key, value in fields.items()}
     details = " ".join(f"{key}={payload[key]}" for key in sorted(payload))
     message = f"[GNOMAN.Menu] {action}"

--- a/tests/test_tui_menu.py
+++ b/tests/test_tui_menu.py
@@ -6,6 +6,8 @@ import sys
 import types
 from typing import Iterable, List
 
+import pytest
+
 
 class FakeWindow:
     """Minimal curses window stub capturing drawn content for assertions."""
@@ -100,3 +102,47 @@ def test_nested_menu_deduplicates_parent_breadcrumbs() -> None:
     assert "Safe › Safe › Proposals" not in header
     assert ctx.stack == ["Safe"]
     assert ctx.current_menu == "Safe"
+
+
+def test_menu_items_have_dispatch_handlers() -> None:
+    top_level_titles = {item["title"] for item in tui.MENU_ITEMS}
+    assert top_level_titles == set(tui.SUBMENU_DISPATCH)
+
+
+def test_submenu_dispatch_registers_back_option(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, list[tuple[str, object | None]]] = {}
+
+    def _fake_open_submenu(ctx: tui.MenuContext, title: str, builder):
+        entries = list(builder(ctx))
+        assert entries, f"{title} must define at least one entry"
+        label, callback = entries[-1]
+        assert callback is None
+        assert label.lower().startswith("back"), "Last entry should be a Back option"
+        captured[title] = entries
+
+    monkeypatch.setattr(tui, "_open_submenu", _fake_open_submenu)
+
+    ctx = tui.MenuContext(stdscr=FakeWindow(inputs=[ord("q")]), palette=_palette())
+    for title, handler in tui.SUBMENU_DISPATCH.items():
+        if title == "About":
+            continue
+        ctx.stack.clear()
+        ctx.current_menu = ""
+        handler(ctx)
+
+    expected = {title for title in tui.SUBMENU_DISPATCH if title != "About"}
+    assert set(captured) == expected
+
+
+def test_about_menu_renders_and_restores_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    window = FakeWindow(inputs=[ord("\n")])
+    ctx = tui.MenuContext(stdscr=window, palette=_palette())
+
+    monkeypatch.setattr(tui, "_legacy_action_about", lambda _ctx: ["Licensed to thrill."])
+
+    tui._show_about_menu(ctx)
+
+    assert ctx.stack == []
+    assert ctx.current_menu == ""
+    footer = window.line(window.height - 2).strip()
+    assert "Press Enter" in footer


### PR DESCRIPTION
## Summary
- update menu logging to use timezone-aware UTC timestamps and preserve the trailing Z format
- add coverage to ensure every submenu builder provides a back entry and that the About panel renders cleanly
- verify that all dashboard menu tiles have matching submenu handlers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1a0a43ac0832c90f720f57ea47aae